### PR TITLE
🐛 Fix: MSW SSR 대응으로 직접 URL 접근 시 API 모킹 정상 처리

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,38 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  webpack: config => {
+    config.resolve.fallback = {
+      ...config.resolve.fallback,
+      fs: false,
+      net: false,
+      dns: false,
+      tls: false,
+      assert: false
+    };
+    return config;
+  },
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: '/api/:path*'
+      }
+    ];
+  },
+  async headers() {
+    return [
+      {
+        source: '/mockServiceWorker.js',
+        headers: [
+          {
+            key: 'Service-Worker-Allowed',
+            value: '/'
+          }
+        ]
+      }
+    ];
+  },
   images: {
     domains: ['picsum.photos'] // 허용할 외부 이미지 호스트네임
   }

--- a/src/components/MSWComponent.tsx
+++ b/src/components/MSWComponent.tsx
@@ -4,17 +4,26 @@ import { useEffect, useState } from 'react';
 
 export const MSWComponent = ({ children }: { children: React.ReactNode }) => {
   const [mswReady, setMswReady] = useState(false);
+
   useEffect(() => {
     const init = async () => {
-      const initMsw = await import('../index').then(res => res.initMsw);
-      await initMsw();
-      setMswReady(true);
+      if (process.env.NODE_ENV === 'development') {
+        const initMsw = await import('../mocks').then(res => res.initMsw);
+        await initMsw();
+        setMswReady(true);
+      } else {
+        setMswReady(true);
+      }
     };
 
     if (!mswReady) {
       init();
     }
   }, [mswReady]);
+
+  if (!mswReady && process.env.NODE_ENV === 'development') {
+    return null; // MSW가 초기화되기 전까지 렌더링 지연
+  }
 
   return <>{children}</>;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,0 @@
-export async function initMsw() {
-  if (typeof window === 'undefined') {
-    const { server } = await import('./mocks/server');
-    server.listen();
-  } else {
-    const { worker } = await import('./mocks/browser');
-    await worker.start();
-  }
-}

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,0 +1,18 @@
+export async function initMsw() {
+  if (process.env.NODE_ENV === 'development') {
+    if (typeof window === 'undefined') {
+      // 서버 사이드에서 실행될 때
+      const { server } = await import('./server');
+      server.listen({ onUnhandledRequest: 'bypass' });
+    } else {
+      // 클라이언트 사이드에서 실행될 때
+      const { worker } = await import('./browser');
+      await worker.start({
+        onUnhandledRequest: 'bypass',
+        serviceWorker: {
+          url: '/mockServiceWorker.js'
+        }
+      });
+    }
+  }
+}


### PR DESCRIPTION
[원인]
- SSR에서 API 호출이 MSW 초기화보다 먼저 발생하여 모킹 실패
- URL 직접 입력 시 404 에러 발생
- Link 컴포넌트를 통한 클라이언트 라우팅에서만 정상 작동

[해결]
1. MSW 초기화 시점 제어
- mswReady 상태로 MSW 준비 상태 추적
- 초기화 전 렌더링 지연으로 API 호출 타이밍 제어

2. Service Worker 설정
- Service-Worker-Allowed 헤더 추가로 전체 도메인에서 MSW 동작 가능
- onUnhandledRequest: 'bypass' 옵션으로 정적 리소스 처리

결과: 직접 URL 입력 시에도 API 모킹 정상 동작