### PR TITLE
📚 Docs :  업데이트된 Swagger문서 기반 openapi-generator 동기화

### DIFF
--- a/src/api/generated/.openapi-generator/FILES
+++ b/src/api/generated/.openapi-generator/FILES
@@ -1,6 +1,5 @@
 .gitignore
 .npmignore
-.openapi-generator-ignore
 api.ts
 base.ts
 common.ts

--- a/src/api/generated/api.ts
+++ b/src/api/generated/api.ts
@@ -195,29 +195,23 @@ export interface ActivityUpdateDTO {
  */
 export interface ChangePasswordDTO {
     /**
-     * 
+     * 사용자 이메일
      * @type {string}
      * @memberof ChangePasswordDTO
      */
     'email'?: string;
     /**
-     * 
+     * 사용자 비밀번호
      * @type {string}
      * @memberof ChangePasswordDTO
      */
     'changePassword'?: string;
     /**
-     * 
+     * 비밀번호 확인
      * @type {string}
      * @memberof ChangePasswordDTO
      */
     'checkChangePassword'?: string;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof ChangePasswordDTO
-     */
-    'same'?: boolean;
 }
 /**
  * 
@@ -368,6 +362,100 @@ export interface EntryPoint {
      */
     'empty'?: boolean;
 }
+/**
+ * 
+ * @export
+ * @interface ErrorResponse
+ */
+export interface ErrorResponse {
+    /**
+     * 
+     * @type {string}
+     * @memberof ErrorResponse
+     */
+    'httpStatus'?: ErrorResponseHttpStatusEnum;
+    /**
+     * 
+     * @type {string}
+     * @memberof ErrorResponse
+     */
+    'message'?: string;
+}
+
+export const ErrorResponseHttpStatusEnum = {
+    _100Continue: '100 CONTINUE',
+    _101SwitchingProtocols: '101 SWITCHING_PROTOCOLS',
+    _102Processing: '102 PROCESSING',
+    _103EarlyHints: '103 EARLY_HINTS',
+    _103Checkpoint: '103 CHECKPOINT',
+    _200Ok: '200 OK',
+    _201Created: '201 CREATED',
+    _202Accepted: '202 ACCEPTED',
+    _203NonAuthoritativeInformation: '203 NON_AUTHORITATIVE_INFORMATION',
+    _204NoContent: '204 NO_CONTENT',
+    _205ResetContent: '205 RESET_CONTENT',
+    _206PartialContent: '206 PARTIAL_CONTENT',
+    _207MultiStatus: '207 MULTI_STATUS',
+    _208AlreadyReported: '208 ALREADY_REPORTED',
+    _226ImUsed: '226 IM_USED',
+    _300MultipleChoices: '300 MULTIPLE_CHOICES',
+    _301MovedPermanently: '301 MOVED_PERMANENTLY',
+    _302Found: '302 FOUND',
+    _302MovedTemporarily: '302 MOVED_TEMPORARILY',
+    _303SeeOther: '303 SEE_OTHER',
+    _304NotModified: '304 NOT_MODIFIED',
+    _305UseProxy: '305 USE_PROXY',
+    _307TemporaryRedirect: '307 TEMPORARY_REDIRECT',
+    _308PermanentRedirect: '308 PERMANENT_REDIRECT',
+    _400BadRequest: '400 BAD_REQUEST',
+    _401Unauthorized: '401 UNAUTHORIZED',
+    _402PaymentRequired: '402 PAYMENT_REQUIRED',
+    _403Forbidden: '403 FORBIDDEN',
+    _404NotFound: '404 NOT_FOUND',
+    _405MethodNotAllowed: '405 METHOD_NOT_ALLOWED',
+    _406NotAcceptable: '406 NOT_ACCEPTABLE',
+    _407ProxyAuthenticationRequired: '407 PROXY_AUTHENTICATION_REQUIRED',
+    _408RequestTimeout: '408 REQUEST_TIMEOUT',
+    _409Conflict: '409 CONFLICT',
+    _410Gone: '410 GONE',
+    _411LengthRequired: '411 LENGTH_REQUIRED',
+    _412PreconditionFailed: '412 PRECONDITION_FAILED',
+    _413PayloadTooLarge: '413 PAYLOAD_TOO_LARGE',
+    _413RequestEntityTooLarge: '413 REQUEST_ENTITY_TOO_LARGE',
+    _414UriTooLong: '414 URI_TOO_LONG',
+    _414RequestUriTooLong: '414 REQUEST_URI_TOO_LONG',
+    _415UnsupportedMediaType: '415 UNSUPPORTED_MEDIA_TYPE',
+    _416RequestedRangeNotSatisfiable: '416 REQUESTED_RANGE_NOT_SATISFIABLE',
+    _417ExpectationFailed: '417 EXPECTATION_FAILED',
+    _418IAmATeapot: '418 I_AM_A_TEAPOT',
+    _419InsufficientSpaceOnResource: '419 INSUFFICIENT_SPACE_ON_RESOURCE',
+    _420MethodFailure: '420 METHOD_FAILURE',
+    _421DestinationLocked: '421 DESTINATION_LOCKED',
+    _422UnprocessableEntity: '422 UNPROCESSABLE_ENTITY',
+    _423Locked: '423 LOCKED',
+    _424FailedDependency: '424 FAILED_DEPENDENCY',
+    _425TooEarly: '425 TOO_EARLY',
+    _426UpgradeRequired: '426 UPGRADE_REQUIRED',
+    _428PreconditionRequired: '428 PRECONDITION_REQUIRED',
+    _429TooManyRequests: '429 TOO_MANY_REQUESTS',
+    _431RequestHeaderFieldsTooLarge: '431 REQUEST_HEADER_FIELDS_TOO_LARGE',
+    _451UnavailableForLegalReasons: '451 UNAVAILABLE_FOR_LEGAL_REASONS',
+    _500InternalServerError: '500 INTERNAL_SERVER_ERROR',
+    _501NotImplemented: '501 NOT_IMPLEMENTED',
+    _502BadGateway: '502 BAD_GATEWAY',
+    _503ServiceUnavailable: '503 SERVICE_UNAVAILABLE',
+    _504GatewayTimeout: '504 GATEWAY_TIMEOUT',
+    _505HttpVersionNotSupported: '505 HTTP_VERSION_NOT_SUPPORTED',
+    _506VariantAlsoNegotiates: '506 VARIANT_ALSO_NEGOTIATES',
+    _507InsufficientStorage: '507 INSUFFICIENT_STORAGE',
+    _508LoopDetected: '508 LOOP_DETECTED',
+    _509BandwidthLimitExceeded: '509 BANDWIDTH_LIMIT_EXCEEDED',
+    _510NotExtended: '510 NOT_EXTENDED',
+    _511NetworkAuthenticationRequired: '511 NETWORK_AUTHENTICATION_REQUIRED'
+} as const;
+
+export type ErrorResponseHttpStatusEnum = typeof ErrorResponseHttpStatusEnum[keyof typeof ErrorResponseHttpStatusEnum];
+
 /**
  * 
  * @export
@@ -1981,6 +2069,12 @@ export interface FieldInfo {
     'name'?: string;
     /**
      * 
+     * @type {Array<FieldInfoTersMethodForFieldInner>}
+     * @memberof FieldInfo
+     */
+    'tersMethodForField'?: Array<FieldInfoTersMethodForFieldInner>;
+    /**
+     * 
      * @type {boolean}
      * @memberof FieldInfo
      */
@@ -1997,12 +2091,6 @@ export interface FieldInfo {
      * @memberof FieldInfo
      */
     'final'?: boolean;
-    /**
-     * 
-     * @type {Array<FieldInfoTersMethodForFieldInner>}
-     * @memberof FieldInfo
-     */
-    'tersMethodForField'?: Array<FieldInfoTersMethodForFieldInner>;
     /**
      * 
      * @type {ClassInfo}
@@ -2429,18 +2517,6 @@ export interface FieldInfoTersMethodForFieldInnerParametersInnerDeclaringExecuta
 export interface FieldInfoTersMethodForFieldInnerParametersInnerDeclaringExecutableTypeParametersInner {
     /**
      * 
-     * @type {string}
-     * @memberof FieldInfoTersMethodForFieldInnerParametersInnerDeclaringExecutableTypeParametersInner
-     */
-    'name'?: string;
-    /**
-     * 
-     * @type {Array<FieldInfoFieldGenericType>}
-     * @memberof FieldInfoTersMethodForFieldInnerParametersInnerDeclaringExecutableTypeParametersInner
-     */
-    'bounds'?: Array<FieldInfoFieldGenericType>;
-    /**
-     * 
      * @type {object}
      * @memberof FieldInfoTersMethodForFieldInnerParametersInnerDeclaringExecutableTypeParametersInner
      */
@@ -2451,6 +2527,18 @@ export interface FieldInfoTersMethodForFieldInnerParametersInnerDeclaringExecuta
      * @memberof FieldInfoTersMethodForFieldInnerParametersInnerDeclaringExecutableTypeParametersInner
      */
     'annotatedBounds'?: Array<FieldInfoFieldAnnotatedType>;
+    /**
+     * 
+     * @type {string}
+     * @memberof FieldInfoTersMethodForFieldInnerParametersInnerDeclaringExecutableTypeParametersInner
+     */
+    'name'?: string;
+    /**
+     * 
+     * @type {Array<FieldInfoFieldGenericType>}
+     * @memberof FieldInfoTersMethodForFieldInnerParametersInnerDeclaringExecutableTypeParametersInner
+     */
+    'bounds'?: Array<FieldInfoFieldGenericType>;
     /**
      * 
      * @type {string}
@@ -2478,6 +2566,12 @@ export interface FieldInfoTersMethodForFieldInnerParametersInnerDeclaringExecuta
 export interface FieldInfoTersMethodForFieldInnerTypeParametersInner {
     /**
      * 
+     * @type {Array<FieldInfoFieldAnnotatedType>}
+     * @memberof FieldInfoTersMethodForFieldInnerTypeParametersInner
+     */
+    'annotatedBounds'?: Array<FieldInfoFieldAnnotatedType>;
+    /**
+     * 
      * @type {string}
      * @memberof FieldInfoTersMethodForFieldInnerTypeParametersInner
      */
@@ -2488,12 +2582,6 @@ export interface FieldInfoTersMethodForFieldInnerTypeParametersInner {
      * @memberof FieldInfoTersMethodForFieldInnerTypeParametersInner
      */
     'bounds'?: Array<FieldInfoFieldGenericType>;
-    /**
-     * 
-     * @type {Array<FieldInfoFieldAnnotatedType>}
-     * @memberof FieldInfoTersMethodForFieldInnerTypeParametersInner
-     */
-    'annotatedBounds'?: Array<FieldInfoFieldAnnotatedType>;
     /**
      * 
      * @type {string}
@@ -2672,13 +2760,13 @@ export interface PageFacilityDetailsResponseDTO {
      * @type {number}
      * @memberof PageFacilityDetailsResponseDTO
      */
-    'totalPages'?: number;
+    'totalElements'?: number;
     /**
      * 
      * @type {number}
      * @memberof PageFacilityDetailsResponseDTO
      */
-    'totalElements'?: number;
+    'totalPages'?: number;
     /**
      * 
      * @type {number}
@@ -2745,13 +2833,13 @@ export interface PageFacilityResponseDTO {
      * @type {number}
      * @memberof PageFacilityResponseDTO
      */
-    'totalPages'?: number;
+    'totalElements'?: number;
     /**
      * 
      * @type {number}
      * @memberof PageFacilityResponseDTO
      */
-    'totalElements'?: number;
+    'totalPages'?: number;
     /**
      * 
      * @type {number}
@@ -2830,6 +2918,12 @@ export interface PageableObject {
      * @type {number}
      * @memberof PageableObject
      */
+    'pageSize'?: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof PageableObject
+     */
     'pageNumber'?: number;
     /**
      * 
@@ -2837,12 +2931,6 @@ export interface PageableObject {
      * @memberof PageableObject
      */
     'paged'?: boolean;
-    /**
-     * 
-     * @type {number}
-     * @memberof PageableObject
-     */
-    'pageSize'?: number;
     /**
      * 
      * @type {boolean}
@@ -2962,91 +3050,67 @@ export interface TagDTO {
  */
 export interface UserChangeInfoDTO {
     /**
-     * 
+     * 변경할 닉네임
      * @type {string}
      * @memberof UserChangeInfoDTO
      */
     'nickname'?: string;
     /**
-     * 
+     * 변경할 소개글
      * @type {string}
      * @memberof UserChangeInfoDTO
      */
     'description'?: string;
 }
 /**
- * 
- * @export
- * @interface UserDTO
- */
-export interface UserDTO {
-    /**
-     * 
-     * @type {string}
-     * @memberof UserDTO
-     */
-    'userid'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof UserDTO
-     */
-    'email'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof UserDTO
-     */
-    'profilePath'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof UserDTO
-     */
-    'nickname'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof UserDTO
-     */
-    'description'?: string;
-}
-/**
- * 
+ * 회원가입 요청 데이터
  * @export
  * @interface UserJoinDTO
  */
 export interface UserJoinDTO {
     /**
-     * 
+     * 사용자 이메일
      * @type {string}
      * @memberof UserJoinDTO
      */
     'email'?: string;
     /**
-     * 
+     * 사용자 비밀번호
      * @type {string}
      * @memberof UserJoinDTO
      */
     'password'?: string;
     /**
-     * 
+     * 비밀번호 확인
      * @type {string}
      * @memberof UserJoinDTO
      */
     'checkPassword'?: string;
     /**
-     * 
+     * 사용자 닉네임
      * @type {string}
      * @memberof UserJoinDTO
      */
     'nickname'?: string;
+}
+/**
+ * 
+ * @export
+ * @interface UserLoginDTO
+ */
+export interface UserLoginDTO {
     /**
-     * 
-     * @type {boolean}
-     * @memberof UserJoinDTO
+     * 사용자 이메일
+     * @type {string}
+     * @memberof UserLoginDTO
      */
-    'same'?: boolean;
+    'email'?: string;
+    /**
+     * 사용자 비밀번호
+     * @type {string}
+     * @memberof UserLoginDTO
+     */
+    'password'?: string;
 }
 
 /**
@@ -3533,6 +3597,207 @@ export class CalendarControllerApi extends BaseAPI {
      */
     public listCalendars(options?: RawAxiosRequestConfig) {
         return CalendarControllerApiFp(this.configuration).listCalendars(options).then((request) => request(this.axios, this.basePath));
+    }
+}
+
+
+
+/**
+ * EmailVerificationControllerApi - axios parameter creator
+ * @export
+ */
+export const EmailVerificationControllerApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * 이메일 인증을 위한 코드를 발송합니다
+         * @summary 이메일 발송
+         * @param {string} email 인증번호를 보낼 email 주소
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        sendCode: async (email: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'email' is not null or undefined
+            assertParamExists('sendCode', 'email', email)
+            const localVarPath = `/api/email`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Bearer Authentication required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            if (email !== undefined) {
+                localVarQueryParameter['email'] = email;
+            }
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 보낸 코드값이 서버의 저장값과 일치하는지 확인합니다
+         * @summary 검증
+         * @param {string} email 인증번호를 보낸 email 주소
+         * @param {string} code 받은 인증번호
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        verifyCode: async (email: string, code: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'email' is not null or undefined
+            assertParamExists('verifyCode', 'email', email)
+            // verify required parameter 'code' is not null or undefined
+            assertParamExists('verifyCode', 'code', code)
+            const localVarPath = `/api/email`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Bearer Authentication required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            if (email !== undefined) {
+                localVarQueryParameter['email'] = email;
+            }
+
+            if (code !== undefined) {
+                localVarQueryParameter['code'] = code;
+            }
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * EmailVerificationControllerApi - functional programming interface
+ * @export
+ */
+export const EmailVerificationControllerApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = EmailVerificationControllerApiAxiosParamCreator(configuration)
+    return {
+        /**
+         * 이메일 인증을 위한 코드를 발송합니다
+         * @summary 이메일 발송
+         * @param {string} email 인증번호를 보낼 email 주소
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async sendCode(email: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.sendCode(email, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['EmailVerificationControllerApi.sendCode']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 보낸 코드값이 서버의 저장값과 일치하는지 확인합니다
+         * @summary 검증
+         * @param {string} email 인증번호를 보낸 email 주소
+         * @param {string} code 받은 인증번호
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async verifyCode(email: string, code: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.verifyCode(email, code, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['EmailVerificationControllerApi.verifyCode']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+    }
+};
+
+/**
+ * EmailVerificationControllerApi - factory interface
+ * @export
+ */
+export const EmailVerificationControllerApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = EmailVerificationControllerApiFp(configuration)
+    return {
+        /**
+         * 이메일 인증을 위한 코드를 발송합니다
+         * @summary 이메일 발송
+         * @param {string} email 인증번호를 보낼 email 주소
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        sendCode(email: string, options?: RawAxiosRequestConfig): AxiosPromise<void> {
+            return localVarFp.sendCode(email, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 보낸 코드값이 서버의 저장값과 일치하는지 확인합니다
+         * @summary 검증
+         * @param {string} email 인증번호를 보낸 email 주소
+         * @param {string} code 받은 인증번호
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        verifyCode(email: string, code: string, options?: RawAxiosRequestConfig): AxiosPromise<void> {
+            return localVarFp.verifyCode(email, code, options).then((request) => request(axios, basePath));
+        },
+    };
+};
+
+/**
+ * EmailVerificationControllerApi - object-oriented interface
+ * @export
+ * @class EmailVerificationControllerApi
+ * @extends {BaseAPI}
+ */
+export class EmailVerificationControllerApi extends BaseAPI {
+    /**
+     * 이메일 인증을 위한 코드를 발송합니다
+     * @summary 이메일 발송
+     * @param {string} email 인증번호를 보낼 email 주소
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof EmailVerificationControllerApi
+     */
+    public sendCode(email: string, options?: RawAxiosRequestConfig) {
+        return EmailVerificationControllerApiFp(this.configuration).sendCode(email, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 보낸 코드값이 서버의 저장값과 일치하는지 확인합니다
+     * @summary 검증
+     * @param {string} email 인증번호를 보낸 email 주소
+     * @param {string} code 받은 인증번호
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof EmailVerificationControllerApi
+     */
+    public verifyCode(email: string, code: string, options?: RawAxiosRequestConfig) {
+        return EmailVerificationControllerApiFp(this.configuration).verifyCode(email, code, options).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -5001,6 +5266,231 @@ export class NotificationControllerApi extends BaseAPI {
 
 
 /**
+ * Oauth2ControllerApi - axios parameter creator
+ * @export
+ */
+export const Oauth2ControllerApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        googleOauth: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/user/oauth2/google`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Bearer Authentication required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        kakaoOauth: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/user/oauth2/kakao`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Bearer Authentication required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        naverOauth: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/user/oauth2/naver`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Bearer Authentication required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * Oauth2ControllerApi - functional programming interface
+ * @export
+ */
+export const Oauth2ControllerApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = Oauth2ControllerApiAxiosParamCreator(configuration)
+    return {
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async googleOauth(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.googleOauth(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['Oauth2ControllerApi.googleOauth']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async kakaoOauth(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.kakaoOauth(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['Oauth2ControllerApi.kakaoOauth']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async naverOauth(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.naverOauth(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['Oauth2ControllerApi.naverOauth']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+    }
+};
+
+/**
+ * Oauth2ControllerApi - factory interface
+ * @export
+ */
+export const Oauth2ControllerApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = Oauth2ControllerApiFp(configuration)
+    return {
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        googleOauth(options?: RawAxiosRequestConfig): AxiosPromise<string> {
+            return localVarFp.googleOauth(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        kakaoOauth(options?: RawAxiosRequestConfig): AxiosPromise<string> {
+            return localVarFp.kakaoOauth(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        naverOauth(options?: RawAxiosRequestConfig): AxiosPromise<string> {
+            return localVarFp.naverOauth(options).then((request) => request(axios, basePath));
+        },
+    };
+};
+
+/**
+ * Oauth2ControllerApi - object-oriented interface
+ * @export
+ * @class Oauth2ControllerApi
+ * @extends {BaseAPI}
+ */
+export class Oauth2ControllerApi extends BaseAPI {
+    /**
+     * 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof Oauth2ControllerApi
+     */
+    public googleOauth(options?: RawAxiosRequestConfig) {
+        return Oauth2ControllerApiFp(this.configuration).googleOauth(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof Oauth2ControllerApi
+     */
+    public kakaoOauth(options?: RawAxiosRequestConfig) {
+        return Oauth2ControllerApiFp(this.configuration).kakaoOauth(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof Oauth2ControllerApi
+     */
+    public naverOauth(options?: RawAxiosRequestConfig) {
+        return Oauth2ControllerApiFp(this.configuration).naverOauth(options).then((request) => request(this.axios, this.basePath));
+    }
+}
+
+
+
+/**
  * PushNotificationControllerApi - axios parameter creator
  * @export
  */
@@ -5537,7 +6027,8 @@ export class TagControllerApi extends BaseAPI {
 export const UserControllerApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
         /**
-         * 
+         * UserId를 이용해 비밀번호를 변경합니다
+         * @summary 비밀번호 변경
          * @param {string} userId 
          * @param {ChangePasswordDTO} changePasswordDTO 
          * @param {*} [options] Override http request option.
@@ -5580,7 +6071,8 @@ export const UserControllerApiAxiosParamCreator = function (configuration?: Conf
             };
         },
         /**
-         * 
+         * UserId를 이용해 프로필 사진을 변경합니다
+         * @summary 프로필 사진 변경
          * @param {string} userId 
          * @param {File} [multipartFile] 
          * @param {*} [options] Override http request option.
@@ -5626,7 +6118,8 @@ export const UserControllerApiAxiosParamCreator = function (configuration?: Conf
             };
         },
         /**
-         * 
+         * UserId를 이용해 회원정보를 삭제합니다
+         * @summary 회원 탈퇴
          * @param {string} userId 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -5663,7 +6156,8 @@ export const UserControllerApiAxiosParamCreator = function (configuration?: Conf
             };
         },
         /**
-         * 
+         * UserId를 이용해 회원정보를 조회합니다
+         * @summary 회원 정보 조회
          * @param {string} userId 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -5700,7 +6194,8 @@ export const UserControllerApiAxiosParamCreator = function (configuration?: Conf
             };
         },
         /**
-         * 
+         * 이메일, 암호, 닉네임을 입력하여 회원가입을 합니다
+         * @summary 회원가입
          * @param {UserJoinDTO} userJoinDTO 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -5739,7 +6234,159 @@ export const UserControllerApiAxiosParamCreator = function (configuration?: Conf
             };
         },
         /**
-         * 
+         * 이메일, 암호를 입력하여 로그인합니다
+         * @summary 로그인
+         * @param {UserLoginDTO} userLoginDTO 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        login: async (userLoginDTO: UserLoginDTO, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'userLoginDTO' is not null or undefined
+            assertParamExists('login', 'userLoginDTO', userLoginDTO)
+            const localVarPath = `/api/user/login`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Bearer Authentication required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(userLoginDTO, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 로그아웃을 합니다.
+         * @summary 로그아웃
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        logout: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/user/logout`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Bearer Authentication required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * (현재미구현)쿠키에 담긴 refresh토큰을 이용해 access토큰을 재발급합니다
+         * @summary 토큰 재발급
+         * @param {string} refreshToken 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        resignAccessTokenByCookie: async (refreshToken: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'refreshToken' is not null or undefined
+            assertParamExists('resignAccessTokenByCookie', 'refreshToken', refreshToken)
+            const localVarPath = `/api/user/refresh/cookie`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Bearer Authentication required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * HTTP헤더에 담긴 refresh_token을 이용해 access_token을 재발급합니다
+         * @summary 토큰 재발급
+         * @param {string} authorization 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        resignAccessTokenByHeader: async (authorization: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'authorization' is not null or undefined
+            assertParamExists('resignAccessTokenByHeader', 'authorization', authorization)
+            const localVarPath = `/api/user/refresh/header`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Bearer Authentication required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            if (authorization != null) {
+                localVarHeaderParameter['Authorization'] = String(authorization);
+            }
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * UserId를 이용해 소개글을 변경합니다
+         * @summary 소개글 변경
          * @param {string} userId 
          * @param {UserChangeInfoDTO} userChangeInfoDTO 
          * @param {*} [options] Override http request option.
@@ -5782,7 +6429,8 @@ export const UserControllerApiAxiosParamCreator = function (configuration?: Conf
             };
         },
         /**
-         * 
+         * UserId를 이용해 닉네임을 변경합니다(도메인 규칙 : 2~10자 사이의 한글,영어소문자,숫자만)
+         * @summary 닉네임 변경
          * @param {string} userId 
          * @param {UserChangeInfoDTO} userChangeInfoDTO 
          * @param {*} [options] Override http request option.
@@ -5835,88 +6483,146 @@ export const UserControllerApiFp = function(configuration?: Configuration) {
     const localVarAxiosParamCreator = UserControllerApiAxiosParamCreator(configuration)
     return {
         /**
-         * 
+         * UserId를 이용해 비밀번호를 변경합니다
+         * @summary 비밀번호 변경
          * @param {string} userId 
          * @param {ChangePasswordDTO} changePasswordDTO 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async changePassword(userId: string, changePasswordDTO: ChangePasswordDTO, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: string; }>> {
+        async changePassword(userId: string, changePasswordDTO: ChangePasswordDTO, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.changePassword(userId, changePasswordDTO, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['UserControllerApi.changePassword']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * 
+         * UserId를 이용해 프로필 사진을 변경합니다
+         * @summary 프로필 사진 변경
          * @param {string} userId 
          * @param {File} [multipartFile] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async changeProfile(userId: string, multipartFile?: File, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: string; }>> {
+        async changeProfile(userId: string, multipartFile?: File, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.changeProfile(userId, multipartFile, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['UserControllerApi.changeProfile']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * 
+         * UserId를 이용해 회원정보를 삭제합니다
+         * @summary 회원 탈퇴
          * @param {string} userId 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async deleteUser(userId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: string; }>> {
+        async deleteUser(userId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.deleteUser(userId, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['UserControllerApi.deleteUser']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * 
+         * UserId를 이용해 회원정보를 조회합니다
+         * @summary 회원 정보 조회
          * @param {string} userId 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async findMyInformation(userId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<UserDTO>> {
+        async findMyInformation(userId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.findMyInformation(userId, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['UserControllerApi.findMyInformation']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * 
+         * 이메일, 암호, 닉네임을 입력하여 회원가입을 합니다
+         * @summary 회원가입
          * @param {UserJoinDTO} userJoinDTO 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async join(userJoinDTO: UserJoinDTO, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<UserDTO>> {
+        async join(userJoinDTO: UserJoinDTO, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.join(userJoinDTO, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['UserControllerApi.join']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * 
+         * 이메일, 암호를 입력하여 로그인합니다
+         * @summary 로그인
+         * @param {UserLoginDTO} userLoginDTO 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async login(userLoginDTO: UserLoginDTO, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.login(userLoginDTO, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['UserControllerApi.login']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 로그아웃을 합니다.
+         * @summary 로그아웃
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async logout(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.logout(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['UserControllerApi.logout']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * (현재미구현)쿠키에 담긴 refresh토큰을 이용해 access토큰을 재발급합니다
+         * @summary 토큰 재발급
+         * @param {string} refreshToken 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async resignAccessTokenByCookie(refreshToken: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.resignAccessTokenByCookie(refreshToken, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['UserControllerApi.resignAccessTokenByCookie']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * HTTP헤더에 담긴 refresh_token을 이용해 access_token을 재발급합니다
+         * @summary 토큰 재발급
+         * @param {string} authorization 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async resignAccessTokenByHeader(authorization: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.resignAccessTokenByHeader(authorization, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['UserControllerApi.resignAccessTokenByHeader']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * UserId를 이용해 소개글을 변경합니다
+         * @summary 소개글 변경
          * @param {string} userId 
          * @param {UserChangeInfoDTO} userChangeInfoDTO 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updateDescription(userId: string, userChangeInfoDTO: UserChangeInfoDTO, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: string; }>> {
+        async updateDescription(userId: string, userChangeInfoDTO: UserChangeInfoDTO, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updateDescription(userId, userChangeInfoDTO, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['UserControllerApi.updateDescription']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * 
+         * UserId를 이용해 닉네임을 변경합니다(도메인 규칙 : 2~10자 사이의 한글,영어소문자,숫자만)
+         * @summary 닉네임 변경
          * @param {string} userId 
          * @param {UserChangeInfoDTO} userChangeInfoDTO 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updateNickname(userId: string, userChangeInfoDTO: UserChangeInfoDTO, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<{ [key: string]: string; }>> {
+        async updateNickname(userId: string, userChangeInfoDTO: UserChangeInfoDTO, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updateNickname(userId, userChangeInfoDTO, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['UserControllerApi.updateNickname']?.[localVarOperationServerIndex]?.url;
@@ -5933,70 +6639,116 @@ export const UserControllerApiFactory = function (configuration?: Configuration,
     const localVarFp = UserControllerApiFp(configuration)
     return {
         /**
-         * 
+         * UserId를 이용해 비밀번호를 변경합니다
+         * @summary 비밀번호 변경
          * @param {string} userId 
          * @param {ChangePasswordDTO} changePasswordDTO 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        changePassword(userId: string, changePasswordDTO: ChangePasswordDTO, options?: RawAxiosRequestConfig): AxiosPromise<{ [key: string]: string; }> {
+        changePassword(userId: string, changePasswordDTO: ChangePasswordDTO, options?: RawAxiosRequestConfig): AxiosPromise<void> {
             return localVarFp.changePassword(userId, changePasswordDTO, options).then((request) => request(axios, basePath));
         },
         /**
-         * 
+         * UserId를 이용해 프로필 사진을 변경합니다
+         * @summary 프로필 사진 변경
          * @param {string} userId 
          * @param {File} [multipartFile] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        changeProfile(userId: string, multipartFile?: File, options?: RawAxiosRequestConfig): AxiosPromise<{ [key: string]: string; }> {
+        changeProfile(userId: string, multipartFile?: File, options?: RawAxiosRequestConfig): AxiosPromise<void> {
             return localVarFp.changeProfile(userId, multipartFile, options).then((request) => request(axios, basePath));
         },
         /**
-         * 
+         * UserId를 이용해 회원정보를 삭제합니다
+         * @summary 회원 탈퇴
          * @param {string} userId 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteUser(userId: string, options?: RawAxiosRequestConfig): AxiosPromise<{ [key: string]: string; }> {
+        deleteUser(userId: string, options?: RawAxiosRequestConfig): AxiosPromise<void> {
             return localVarFp.deleteUser(userId, options).then((request) => request(axios, basePath));
         },
         /**
-         * 
+         * UserId를 이용해 회원정보를 조회합니다
+         * @summary 회원 정보 조회
          * @param {string} userId 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        findMyInformation(userId: string, options?: RawAxiosRequestConfig): AxiosPromise<UserDTO> {
+        findMyInformation(userId: string, options?: RawAxiosRequestConfig): AxiosPromise<void> {
             return localVarFp.findMyInformation(userId, options).then((request) => request(axios, basePath));
         },
         /**
-         * 
+         * 이메일, 암호, 닉네임을 입력하여 회원가입을 합니다
+         * @summary 회원가입
          * @param {UserJoinDTO} userJoinDTO 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        join(userJoinDTO: UserJoinDTO, options?: RawAxiosRequestConfig): AxiosPromise<UserDTO> {
+        join(userJoinDTO: UserJoinDTO, options?: RawAxiosRequestConfig): AxiosPromise<void> {
             return localVarFp.join(userJoinDTO, options).then((request) => request(axios, basePath));
         },
         /**
-         * 
+         * 이메일, 암호를 입력하여 로그인합니다
+         * @summary 로그인
+         * @param {UserLoginDTO} userLoginDTO 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        login(userLoginDTO: UserLoginDTO, options?: RawAxiosRequestConfig): AxiosPromise<void> {
+            return localVarFp.login(userLoginDTO, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 로그아웃을 합니다.
+         * @summary 로그아웃
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        logout(options?: RawAxiosRequestConfig): AxiosPromise<void> {
+            return localVarFp.logout(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * (현재미구현)쿠키에 담긴 refresh토큰을 이용해 access토큰을 재발급합니다
+         * @summary 토큰 재발급
+         * @param {string} refreshToken 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        resignAccessTokenByCookie(refreshToken: string, options?: RawAxiosRequestConfig): AxiosPromise<void> {
+            return localVarFp.resignAccessTokenByCookie(refreshToken, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * HTTP헤더에 담긴 refresh_token을 이용해 access_token을 재발급합니다
+         * @summary 토큰 재발급
+         * @param {string} authorization 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        resignAccessTokenByHeader(authorization: string, options?: RawAxiosRequestConfig): AxiosPromise<void> {
+            return localVarFp.resignAccessTokenByHeader(authorization, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * UserId를 이용해 소개글을 변경합니다
+         * @summary 소개글 변경
          * @param {string} userId 
          * @param {UserChangeInfoDTO} userChangeInfoDTO 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateDescription(userId: string, userChangeInfoDTO: UserChangeInfoDTO, options?: RawAxiosRequestConfig): AxiosPromise<{ [key: string]: string; }> {
+        updateDescription(userId: string, userChangeInfoDTO: UserChangeInfoDTO, options?: RawAxiosRequestConfig): AxiosPromise<void> {
             return localVarFp.updateDescription(userId, userChangeInfoDTO, options).then((request) => request(axios, basePath));
         },
         /**
-         * 
+         * UserId를 이용해 닉네임을 변경합니다(도메인 규칙 : 2~10자 사이의 한글,영어소문자,숫자만)
+         * @summary 닉네임 변경
          * @param {string} userId 
          * @param {UserChangeInfoDTO} userChangeInfoDTO 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateNickname(userId: string, userChangeInfoDTO: UserChangeInfoDTO, options?: RawAxiosRequestConfig): AxiosPromise<{ [key: string]: string; }> {
+        updateNickname(userId: string, userChangeInfoDTO: UserChangeInfoDTO, options?: RawAxiosRequestConfig): AxiosPromise<void> {
             return localVarFp.updateNickname(userId, userChangeInfoDTO, options).then((request) => request(axios, basePath));
         },
     };
@@ -6010,7 +6762,8 @@ export const UserControllerApiFactory = function (configuration?: Configuration,
  */
 export class UserControllerApi extends BaseAPI {
     /**
-     * 
+     * UserId를 이용해 비밀번호를 변경합니다
+     * @summary 비밀번호 변경
      * @param {string} userId 
      * @param {ChangePasswordDTO} changePasswordDTO 
      * @param {*} [options] Override http request option.
@@ -6022,7 +6775,8 @@ export class UserControllerApi extends BaseAPI {
     }
 
     /**
-     * 
+     * UserId를 이용해 프로필 사진을 변경합니다
+     * @summary 프로필 사진 변경
      * @param {string} userId 
      * @param {File} [multipartFile] 
      * @param {*} [options] Override http request option.
@@ -6034,7 +6788,8 @@ export class UserControllerApi extends BaseAPI {
     }
 
     /**
-     * 
+     * UserId를 이용해 회원정보를 삭제합니다
+     * @summary 회원 탈퇴
      * @param {string} userId 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -6045,7 +6800,8 @@ export class UserControllerApi extends BaseAPI {
     }
 
     /**
-     * 
+     * UserId를 이용해 회원정보를 조회합니다
+     * @summary 회원 정보 조회
      * @param {string} userId 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -6056,7 +6812,8 @@ export class UserControllerApi extends BaseAPI {
     }
 
     /**
-     * 
+     * 이메일, 암호, 닉네임을 입력하여 회원가입을 합니다
+     * @summary 회원가입
      * @param {UserJoinDTO} userJoinDTO 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -6067,7 +6824,55 @@ export class UserControllerApi extends BaseAPI {
     }
 
     /**
-     * 
+     * 이메일, 암호를 입력하여 로그인합니다
+     * @summary 로그인
+     * @param {UserLoginDTO} userLoginDTO 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof UserControllerApi
+     */
+    public login(userLoginDTO: UserLoginDTO, options?: RawAxiosRequestConfig) {
+        return UserControllerApiFp(this.configuration).login(userLoginDTO, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 로그아웃을 합니다.
+     * @summary 로그아웃
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof UserControllerApi
+     */
+    public logout(options?: RawAxiosRequestConfig) {
+        return UserControllerApiFp(this.configuration).logout(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * (현재미구현)쿠키에 담긴 refresh토큰을 이용해 access토큰을 재발급합니다
+     * @summary 토큰 재발급
+     * @param {string} refreshToken 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof UserControllerApi
+     */
+    public resignAccessTokenByCookie(refreshToken: string, options?: RawAxiosRequestConfig) {
+        return UserControllerApiFp(this.configuration).resignAccessTokenByCookie(refreshToken, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * HTTP헤더에 담긴 refresh_token을 이용해 access_token을 재발급합니다
+     * @summary 토큰 재발급
+     * @param {string} authorization 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof UserControllerApi
+     */
+    public resignAccessTokenByHeader(authorization: string, options?: RawAxiosRequestConfig) {
+        return UserControllerApiFp(this.configuration).resignAccessTokenByHeader(authorization, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * UserId를 이용해 소개글을 변경합니다
+     * @summary 소개글 변경
      * @param {string} userId 
      * @param {UserChangeInfoDTO} userChangeInfoDTO 
      * @param {*} [options] Override http request option.
@@ -6079,7 +6884,8 @@ export class UserControllerApi extends BaseAPI {
     }
 
     /**
-     * 
+     * UserId를 이용해 닉네임을 변경합니다(도메인 규칙 : 2~10자 사이의 한글,영어소문자,숫자만)
+     * @summary 닉네임 변경
      * @param {string} userId 
      * @param {UserChangeInfoDTO} userChangeInfoDTO 
      * @param {*} [options] Override http request option.

--- a/swagger.json
+++ b/swagger.json
@@ -1,1 +1,4053 @@
-{"openapi":"3.0.1","info":{"title":"PublicPlus","description":"공공체육시설 활성화 사이트 공공플러스입니다!","contact":{"name":"데브코스 통합 파이널 프로젝트 11팀 00+ 백엔드 깃허브 채널","url":"https://github.com/prgrms-web-devcourse-final-project/WEB1_2_PublicPlus_BE"},"version":"1.0"},"servers":[{"url":"http://localhost:8080","description":"Generated server url"}],"security":[{"Bearer Authentication":[]}],"tags":[{"name":"FacilityController","description":"시설 검색정보, 상세정보를 다루는 API입니다."}],"paths":{"/api/meetingboard/{mbId}":{"get":{"tags":["meeting-board-controller"],"operationId":"getMeetingBoardById","parameters":[{"name":"mbId","in":"path","required":true,"schema":{"type":"integer","format":"int64"}}],"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"object"}}}}}},"put":{"tags":["meeting-board-controller"],"operationId":"updateMeetingBoard","parameters":[{"name":"mbId","in":"path","required":true,"schema":{"type":"integer","format":"int64"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/MeetingBoardRequestDTO"}}},"required":true},"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"object"}}}}}},"delete":{"tags":["meeting-board-controller"],"operationId":"deleteMeetingBoard","parameters":[{"name":"mbId","in":"path","required":true,"schema":{"type":"integer","format":"int64"}}],"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"object"}}}}}}},"/api/google-calendar/event":{"put":{"tags":["event-controller"],"operationId":"updateEvent","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ActivityUpdateDTO"}}},"required":true},"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"object"}}}}}},"post":{"tags":["event-controller"],"operationId":"createEvent","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ActivityCreateDTO"}}},"required":true},"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"object"}}}}}}},"/api/facility-details/{id}/reviews/{reviewId}":{"put":{"tags":["review-controller"],"operationId":"updateReview","parameters":[{"name":"reviewId","in":"path","required":true,"schema":{"type":"integer","format":"int64"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ReviewDTO"}}},"required":true},"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"$ref":"#/components/schemas/ReviewDTO"}}}}}},"delete":{"tags":["review-controller"],"operationId":"deleteReview","parameters":[{"name":"reviewId","in":"path","required":true,"schema":{"type":"integer","format":"int64"}}],"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"object"}}}}}}},"/api/facility-detail/{facilityId}":{"get":{"tags":["FacilityController"],"summary":"시설 상세 정보 페이지 조회","description":"시설 ID로 상세 정보를 조회합니다.","operationId":"readFacilityDetails","parameters":[{"name":"facilityId","in":"path","required":true,"schema":{"type":"string"}}],"responses":{"404":{"description":"시설을 찾을 수 없습니다.","content":{"*/*":{"schema":{"$ref":"#/components/schemas/FacilityDetailsResponseDTO"}}}},"200":{"description":"성공적으로 시설 상세 정보를 조회했습니다.","content":{"*/*":{"schema":{"$ref":"#/components/schemas/FacilityDetailsResponseDTO"}}}}}},"put":{"tags":["FacilityController"],"summary":"시설 상세 정보 업데이트","description":"시설 상세 정보를 업데이트합니다.","operationId":"updateFacilityDetail","parameters":[{"name":"facilityId","in":"path","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/FacilityDetailsUpdateDTO"}}},"required":true},"responses":{"200":{"description":"성공적으로 시설 상세 정보가 업데이트되었습니다.","content":{"application/json":{"schema":{"$ref":"#/components/schemas/FacilityDetailsResponseDTO"},"example":{"facilityId":"S210401100008601453","facilityName":"○ [평일] (주간) 마포 난지천 인조잔디축구장 (업데이트)","facilityCategory":"FOOTBALL_FIELD","area":"마포구","priceType":true,"facilityImage":"https://example.com/image.jpg","reservationStartDate":"2024-11-27T01:44:05.959Z","reservationEndDate":"2024-11-27T01:44:05.959Z","facilityNumber":"02-3153-9874","reservationURL":"https://example.com/reserve","facilityLocation":"서울특별시 산악문화체험센터>난지천인조잔디축구장","facilityDescription":"1. 공공시설 예약서비스 이용시 필수 준수사항...","serviceStartDate":"2024-01-01","serviceEndDate":"2024-12-31"}}}},"404":{"description":"시설을 찾을 수 없습니다.","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ErrorResponseDTO"},"example":{"message":"Facility not found"}}}},"400":{"description":"업데이트 실패","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ErrorResponseDTO"},"example":{"message":"Invalid input data"}}}}}},"delete":{"tags":["FacilityController"],"summary":"시설 상세 정보 삭제","description":"시설 상세 정보를 삭제합니다.","operationId":"deleteFacilityDetail","parameters":[{"name":"facilityId","in":"path","required":true,"schema":{"type":"string"}}],"responses":{"404":{"description":"시설을 찾을 수 없습니다.","content":{"*/*":{"schema":{"type":"object","additionalProperties":{"type":"string"}}}}},"200":{"description":"성공적으로 시설 상세 정보가 삭제되었습니다.","content":{"*/*":{"schema":{"type":"object","additionalProperties":{"type":"string"}}}}},"400":{"description":"삭제 실패","content":{"*/*":{"schema":{"type":"object","additionalProperties":{"type":"string"}}}}}}}},"/api/activity/{activityId}":{"get":{"tags":["activity-controller"],"operationId":"getActivity","parameters":[{"name":"activityId","in":"path","required":true,"schema":{"type":"integer","format":"int64"}}],"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"$ref":"#/components/schemas/ActivityResponseDTO"}}}}}},"put":{"tags":["activity-controller"],"operationId":"updateActivity","parameters":[{"name":"activityId","in":"path","required":true,"schema":{"type":"integer","format":"int64"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ActivityUpdateDTO"}}},"required":true},"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"$ref":"#/components/schemas/ActivityResponseDTO"}}}}}},"delete":{"tags":["activity-controller"],"operationId":"deleteActivity","parameters":[{"name":"activityId","in":"path","required":true,"schema":{"type":"integer","format":"int64"}}],"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"object","additionalProperties":{"type":"string"}}}}}}}},"/calendar/{summary}":{"post":{"tags":["calendar-controller"],"operationId":"createCalendar","parameters":[],"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"object"}}}}}}},"/api/user/profile/{userId}":{"post":{"tags":["user-controller"],"operationId":"changeProfile","parameters":[{"name":"userId","in":"path","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"multipart/form-data":{"schema":{"type":"object","properties":{"multipartFile":{"type":"string","format":"binary"}}}}}},"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"object","additionalProperties":{"type":"string"}}}}}}}},"/api/user/password/{userId}":{"post":{"tags":["user-controller"],"operationId":"changePassword","parameters":[{"name":"userId","in":"path","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ChangePasswordDTO"}}},"required":true},"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"object","additionalProperties":{"type":"string"}}}}}}}},"/api/user/join":{"post":{"tags":["user-controller"],"operationId":"join","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/UserJoinDTO"}}},"required":true},"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"$ref":"#/components/schemas/UserDTO"}}}}}}},"/api/push/send":{"post":{"tags":["push-notification-controller"],"operationId":"sendPushNotification","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/NotificationCreateDTO"}}},"required":true},"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"string"}}}}}}},"/api/notification/send":{"post":{"tags":["notification-controller"],"operationId":"sendPushNotification_1","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/NotificationDTO"}}},"required":true},"responses":{"200":{"description":"OK"}}}},"/api/meetingboard":{"get":{"tags":["meeting-board-controller"],"operationId":"getAllMeetingBoards","responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"object"}}}}}},"post":{"tags":["meeting-board-controller"],"operationId":"createMeetingBoard","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/MeetingBoardRequestDTO"}}},"required":true},"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"object"}}}}}}},"/api/fcm/save-token":{"post":{"tags":["fcm-controller"],"operationId":"saveToken","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/FCMTokenRequest"}}},"required":true},"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"string"}}}}}}},"/api/facility-details/{id}/reviews":{"get":{"tags":["review-controller"],"operationId":"getReviewsByFacility","parameters":[],"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"object","additionalProperties":{"type":"object"}}}}}}},"post":{"tags":["review-controller"],"operationId":"createReview","parameters":[],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ReviewDTO"}}},"required":true},"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"$ref":"#/components/schemas/ReviewDTO"}}}}}}},"/api/facility-detail/filter":{"post":{"tags":["FacilityController"],"summary":"시설 필터링 검색","description":"시설 검색정보를 여러 조건으로 필터링하여 조회합니다.","operationId":"facilityFilter","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/FacilityFilterDTO"}}},"required":true},"responses":{"200":{"description":"필터링된 시설 목록 조회 성공","content":{"*/*":{"schema":{"$ref":"#/components/schemas/PageFacilityResponseDTO"}}}},"400":{"description":"필터링 에러","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ErrorResponseDTO"},"example":{"message":"Invalid input data"}}}}}}},"/api/facility-detail/all-memory":{"post":{"tags":["FacilityController"],"summary":"모든 시설 상세 정보 저장","description":"서울시 공공 서비스예약의 모든 시설 데이터를 API를 통해 가져와서 저장합니다.","operationId":"addAllFacilityDetails","responses":{"400":{"description":"데이터 수집에 실패했습니다.","content":{"*/*":{"schema":{"type":"object"}}}},"200":{"description":"성공적으로 모든 시설 상세 정보를 저장했습니다.","content":{"*/*":{"schema":{"type":"object"}}}}}}},"/api/activity":{"post":{"tags":["activity-controller"],"operationId":"createActivity","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ActivityCreateDTO"}}},"required":true},"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"$ref":"#/components/schemas/ActivityResponseDTO"}}}}}}},"/api/user/nickname/{userId}":{"patch":{"tags":["user-controller"],"operationId":"updateNickname","parameters":[{"name":"userId","in":"path","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/UserChangeInfoDTO"}}},"required":true},"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"object","additionalProperties":{"type":"string"}}}}}}}},"/api/user/description/{userId}":{"patch":{"tags":["user-controller"],"operationId":"updateDescription","parameters":[{"name":"userId","in":"path","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/UserChangeInfoDTO"}}},"required":true},"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"object","additionalProperties":{"type":"string"}}}}}}}},"/tags":{"get":{"tags":["tag-controller"],"operationId":"getTags","responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/TagDTO"}}}}}}}},"/calendars":{"get":{"tags":["calendar-controller"],"operationId":"listCalendars","responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"object"}}}}}}},"/api/user/{userId}":{"get":{"tags":["user-controller"],"operationId":"findMyInformation","parameters":[{"name":"userId","in":"path","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"$ref":"#/components/schemas/UserDTO"}}}}}},"delete":{"tags":["user-controller"],"operationId":"deleteUser","parameters":[{"name":"userId","in":"path","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"object","additionalProperties":{"type":"string"}}}}}}}},"/api/google-calendar/event/events":{"get":{"tags":["event-controller"],"operationId":"listEvents","responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"$ref":"#/components/schemas/Events"}}}}}}},"/api/facility-detail/list":{"get":{"tags":["FacilityController"],"summary":"시설 목록 페이지 조회","description":"모든 시설 목록을 페이지 단위로 조회합니다.","operationId":"getAllFacilities","responses":{"200":{"description":"시설 목록 조회 성공","content":{"application/json":{"schema":{"$ref":"#/components/schemas/FacilityPageResponseDTO"},"example":{"content":[{"facilityId":"S210401100008601453","facilityName":"마포 난지천 인조잔디축구장","area":"마포구","facilityCategory":"FOOTBALL_FIELD","reservationStartDate":"2024-11-27T01:44:05.959Z","reservationEndDate":"2024-11-27T01:44:05.959Z"},{"facilityId":"S210401100008601454","facilityName":"강동구 실내 배드민턴장","area":"강동구","facilityCategory":"BADMINTON_COURT","reservationStartDate":"2024-11-28T01:44:05.959Z","reservationEndDate":"2024-11-28T01:44:05.959Z"}],"pageable":{"pageNumber":0,"pageSize":10,"sort":{"sorted":true,"unsorted":false,"empty":false}},"totalElements":200,"totalPages":20,"last":false,"first":true,"size":10,"number":0,"sort":{"sorted":true,"unsorted":false,"empty":false},"numberOfElements":10}}}}}}},"/api/facility-detail/details":{"get":{"tags":["FacilityController"],"summary":"시설 상세 정보 목록 조회","description":"모든 시설 상세 정보를 페이지 단위로 조회합니다.","operationId":"getAllFacilityDetails","responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"$ref":"#/components/schemas/PageFacilityDetailsResponseDTO"}}}}}}},"/api/google-calendar/event/eventId":{"delete":{"tags":["event-controller"],"operationId":"deleteEvent","requestBody":{"content":{"application/json":{"schema":{"type":"string"}}},"required":true},"responses":{"200":{"description":"OK","content":{"*/*":{"schema":{"type":"string"}}}}}}}},"components":{"schemas":{"LocalTime":{"type":"object","properties":{"hour":{"type":"integer","format":"int32"},"minute":{"type":"integer","format":"int32"},"second":{"type":"integer","format":"int32"},"nano":{"type":"integer","format":"int32"}}},"MeetingBoardRequestDTO":{"required":["maxParticipants","mbContent","mbDate","mbHost","mbLocation","mbTime","mbTitle","sportType"],"type":"object","properties":{"sportType":{"type":"string","enum":["BADMINTON","BASEBALL","BASKETBALL","SOCCER","SWIMMING","TENNIS"]},"mbTitle":{"type":"string"},"mbContent":{"maxLength":500,"minLength":0,"type":"string"},"mbDate":{"type":"string","format":"date"},"mbTime":{"$ref":"#/components/schemas/LocalTime"},"mbLocation":{"type":"string"},"mbHost":{"type":"string"},"maxParticipants":{"type":"integer","format":"int32"}}},"ActivityUpdateDTO":{"type":"object","properties":{"title":{"type":"string"},"eventId":{"type":"string"},"description":{"type":"string"},"location":{"type":"string"},"startTime":{"type":"string"},"endTime":{"type":"string"},"googleCalenderId":{"type":"string"},"maxAttendees":{"type":"integer","format":"int32"}}},"ReviewDTO":{"type":"object","properties":{"id":{"type":"integer","format":"int64"},"facilityId":{"type":"string"},"content":{"type":"string"},"rating":{"type":"number","format":"double"},"tags":{"type":"array","items":{"type":"string"}},"likes":{"type":"integer","format":"int32"},"views":{"type":"integer","format":"int32"}}},"FacilityDetailsUpdateDTO":{"type":"object","properties":{"facilityId":{"type":"string","description":"시설 고유 ID","example":"S210401100008601453"},"facilityName":{"type":"string","description":"시설 이름","example":"○ [평일] (주간) 마포 난지천 인조잔디축구장 (업데이트)"},"facilityCategory":{"type":"string","description":"시설 카테고리","example":"FOOTBALL","enum":["FOOTBALL_FIELD","FUTSAL_FIELD","FOOT_VOLLEYBALL_FIELD","BASEBALL_FIELD","TENNIS_FIELD","BASKETBALL_FIELD","VOLLEYBALL_FIELD","MULTIPURPOSE_FIELD","SPORTS_FIELD","GYM","BADMINTON_FIELD","TABLE_TENNIS_FIELD","EDUCATIONAL_FACILITY","SWIMMING_POOL","GOLF_FIELD"]},"area":{"type":"string","description":"시설 지역","example":"마포구"},"priceType":{"type":"boolean","description":"무료(true) / 유료(false)","example":true},"facilityImage":{"type":"string","description":"시설 이미지 URL","example":"http://example.com/facility.jpg"},"reservationStartDate":{"type":"string","description":"서비스 시작 날짜","format":"date-time"},"reservationEndDate":{"type":"string","description":"서비스 종료 날짜","format":"date-time"},"facilityNumber":{"type":"string","description":"시설 전화번호","example":"02-3153-9874"},"reservationURL":{"type":"string","description":"예약 URL","example":"http://example.com/reservation"},"facilityLocation":{"type":"string","description":"시설 상세 주소","example":"서울특별시 산악문화체험센터>난지천인조잔디축구장"},"facilityDescription":{"type":"string","description":"시설 설명","example":"1. 공공시설 예약서비스 이용시 필수 준수사항..."},"serviceStartDate":{"type":"string","description":"서비스 시작 날짜 (String 형식)","example":"2024-01-01"},"serviceEndDate":{"type":"string","description":"서비스 종료 날짜 (String 형식)","example":"2024-12-31"}}},"FacilityDetailsResponseDTO":{"type":"object","properties":{"facilityId":{"type":"string","description":"시설 고유 ID","example":"S210401100008601453"},"facilityName":{"type":"string","description":"시설 이름","example":"○ [평일] (주간) 마포 난지천 인조잔디축구장"},"facilityCategory":{"type":"string","description":"시설 카테고리","example":"FOOTBALL_FIELD","enum":["FOOTBALL_FIELD","FUTSAL_FIELD","FOOT_VOLLEYBALL_FIELD","BASEBALL_FIELD","TENNIS_FIELD","BASKETBALL_FIELD","VOLLEYBALL_FIELD","MULTIPURPOSE_FIELD","SPORTS_FIELD","GYM","BADMINTON_FIELD","TABLE_TENNIS_FIELD","EDUCATIONAL_FACILITY","SWIMMING_POOL","GOLF_FIELD"]},"area":{"type":"string","description":"시설 지역","example":"마포구"},"priceType":{"type":"boolean","description":"무료/유료 여부","example":true},"facilityImage":{"type":"string","description":"시설 이미지 URL","example":"https://example.com/image.jpg"},"reservationStartDate":{"type":"string","description":"예약 시작 날짜","format":"date-time"},"reservationEndDate":{"type":"string","description":"예약 종료 날짜","format":"date-time"},"facilityNumber":{"type":"string","description":"시설 전화번호","example":"02-3153-9874"},"reservationURL":{"type":"string","description":"시설 예약 URL","example":"https://example.com/reserve"},"facilityLocation":{"type":"string","description":"시설 상세 주소","example":"서울특별시 산악문화체험센터>난지천인조잔디축구장"},"facilityDescription":{"type":"string","description":"시설 설명","example":"1. 공공시설 예약서비스 이용시 필수 준수사항..."},"serviceStartDate":{"type":"string","description":"서비스 시작 날짜","example":"2024-01-01"},"serviceEndDate":{"type":"string","description":"서비스 종료 날짜","example":"2024-12-31"}}},"ErrorResponseDTO":{"type":"object","properties":{"errorCode":{"type":"string","description":"에러 코드"},"message":{"type":"string","description":"에러 메시지"},"details":{"type":"string","description":"에러에 대한 세부 설명"}}},"ActivityResponseDTO":{"type":"object","properties":{"title":{"type":"string"},"description":{"type":"string"},"location":{"type":"string"},"startTime":{"type":"string"},"endTime":{"type":"string"},"maxParticipants":{"type":"integer","format":"int32"},"currentParticipants":{"type":"integer","format":"int32"},"eventId":{"type":"string"}}},"ChangePasswordDTO":{"type":"object","properties":{"email":{"type":"string"},"changePassword":{"type":"string"},"checkChangePassword":{"type":"string"},"same":{"type":"boolean"}}},"UserJoinDTO":{"type":"object","properties":{"email":{"type":"string"},"password":{"type":"string"},"checkPassword":{"type":"string"},"nickname":{"type":"string"},"same":{"type":"boolean"}}},"UserDTO":{"type":"object","properties":{"userid":{"type":"string"},"email":{"type":"string"},"profilePath":{"type":"string"},"nickname":{"type":"string"},"description":{"type":"string"}}},"NotificationCreateDTO":{"type":"object","properties":{"title":{"type":"string"},"body":{"type":"string"}}},"NotificationDTO":{"type":"object","properties":{"notificationId":{"type":"integer","format":"int64"},"title":{"type":"string"},"message":{"type":"string"},"userId":{"type":"string"}}},"ActivityCreateDTO":{"type":"object","properties":{"title":{"type":"string"},"eventId":{"type":"string"},"description":{"type":"string"},"location":{"type":"string"},"startTime":{"type":"string"},"endTime":{"type":"string"},"googleCalenderId":{"type":"string"},"maxAttendees":{"type":"integer","format":"int32"}}},"FCMTokenRequest":{"type":"object","properties":{"userId":{"type":"string"},"token":{"type":"string"}}},"FacilityFilterDTO":{"type":"object","properties":{"facilityName":{"type":"string","description":"시설 이름"},"facilityCategory":{"type":"string","description":"시설 카테고리","example":"축구장","default":"축구장"},"area":{"type":"string","description":"시설 지역","example":"마포구","default":"마포구"},"priceType":{"type":"boolean","description":"시설 가격 유형(무료/유료)","example":true,"default":true}}},"FacilityResponseDTO":{"type":"object","properties":{"facilityId":{"type":"string"},"facilityName":{"type":"string"},"facilityCategory":{"type":"string","enum":["FOOTBALL_FIELD","FUTSAL_FIELD","FOOT_VOLLEYBALL_FIELD","BASEBALL_FIELD","TENNIS_FIELD","BASKETBALL_FIELD","VOLLEYBALL_FIELD","MULTIPURPOSE_FIELD","SPORTS_FIELD","GYM","BADMINTON_FIELD","TABLE_TENNIS_FIELD","EDUCATIONAL_FACILITY","SWIMMING_POOL","GOLF_FIELD"]},"area":{"type":"string"},"priceType":{"type":"boolean"},"facilityImage":{"type":"string"},"reservationStartDate":{"type":"string","format":"date-time"},"reservationEndDate":{"type":"string","format":"date-time"}}},"PageFacilityResponseDTO":{"type":"object","properties":{"totalPages":{"type":"integer","format":"int32"},"totalElements":{"type":"integer","format":"int64"},"size":{"type":"integer","format":"int32"},"content":{"type":"array","items":{"$ref":"#/components/schemas/FacilityResponseDTO"}},"number":{"type":"integer","format":"int32"},"sort":{"type":"array","items":{"$ref":"#/components/schemas/SortObject"}},"first":{"type":"boolean"},"last":{"type":"boolean"},"numberOfElements":{"type":"integer","format":"int32"},"pageable":{"$ref":"#/components/schemas/PageableObject"},"empty":{"type":"boolean"}}},"PageableObject":{"type":"object","properties":{"offset":{"type":"integer","format":"int64"},"sort":{"type":"array","items":{"$ref":"#/components/schemas/SortObject"}},"pageNumber":{"type":"integer","format":"int32"},"paged":{"type":"boolean"},"pageSize":{"type":"integer","format":"int32"},"unpaged":{"type":"boolean"}}},"SortObject":{"type":"object","properties":{"direction":{"type":"string"},"nullHandling":{"type":"string"},"ascending":{"type":"boolean"},"property":{"type":"string"},"ignoreCase":{"type":"boolean"}}},"UserChangeInfoDTO":{"type":"object","properties":{"nickname":{"type":"string"},"description":{"type":"string"}}},"TagDTO":{"type":"object","properties":{"value":{"type":"string"},"type":{"type":"string"}}},"ClassInfo":{"type":"object","properties":{"ignoreCase":{"type":"boolean"},"names":{"type":"array","items":{"type":"string"}},"enum":{"type":"boolean"},"fieldInfos":{"type":"array","items":{"$ref":"#/components/schemas/FieldInfo"}}}},"DateTime":{"type":"object","properties":{"value":{"type":"integer","format":"int64"},"dateOnly":{"type":"boolean"},"timeZoneShift":{"type":"integer","format":"int32"}}},"EntryPoint":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"accessCode":{"type":"string"},"entryPointFeatures":{"type":"array","items":{"type":"string"}},"entryPointType":{"type":"string"},"label":{"type":"string"},"meetingCode":{"type":"string"},"passcode":{"type":"string"},"password":{"type":"string"},"pin":{"type":"string"},"regionCode":{"type":"string"},"uri":{"type":"string"},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"Event":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"anyoneCanAddSelf":{"type":"boolean"},"attachments":{"type":"array","items":{"$ref":"#/components/schemas/EventAttachment"}},"attendees":{"type":"array","items":{"$ref":"#/components/schemas/EventAttendee"}},"attendeesOmitted":{"type":"boolean"},"colorId":{"type":"string"},"conferenceData":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"conferenceId":{"type":"string"},"conferenceSolution":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"iconUri":{"type":"string"},"key":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"type":{"type":"string"},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"name":{"type":"string"},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"createRequest":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"conferenceSolutionKey":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"type":{"type":"string"},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"requestId":{"type":"string"},"status":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"statusCode":{"type":"string"},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"entryPoints":{"type":"array","items":{"$ref":"#/components/schemas/EntryPoint"}},"notes":{"type":"string"},"parameters":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"addOnParameters":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"parameters":{"type":"object","additionalProperties":{"type":"string"}},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"signature":{"type":"string"},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"created":{"$ref":"#/components/schemas/DateTime"},"creator":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"displayName":{"type":"string"},"email":{"type":"string"},"id":{"type":"string"},"self":{"type":"boolean"},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"description":{"type":"string"},"end":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"date":{"$ref":"#/components/schemas/DateTime"},"dateTime":{"$ref":"#/components/schemas/DateTime"},"timeZone":{"type":"string"},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"endTimeUnspecified":{"type":"boolean"},"etag":{"type":"string"},"extendedProperties":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"shared":{"type":"object","additionalProperties":{"type":"string"}},"private":{"type":"object","additionalProperties":{"type":"string"}},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"gadget":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"display":{"type":"string"},"height":{"type":"integer","format":"int32"},"iconLink":{"type":"string"},"link":{"type":"string"},"preferences":{"type":"object","additionalProperties":{"type":"string"}},"title":{"type":"string"},"type":{"type":"string"},"width":{"type":"integer","format":"int32"},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"guestsCanInviteOthers":{"type":"boolean"},"guestsCanModify":{"type":"boolean"},"guestsCanSeeOtherGuests":{"type":"boolean"},"hangoutLink":{"type":"string"},"htmlLink":{"type":"string"},"id":{"type":"string"},"kind":{"type":"string"},"location":{"type":"string"},"locked":{"type":"boolean"},"organizer":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"displayName":{"type":"string"},"email":{"type":"string"},"id":{"type":"string"},"self":{"type":"boolean"},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"originalStartTime":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"date":{"$ref":"#/components/schemas/DateTime"},"dateTime":{"$ref":"#/components/schemas/DateTime"},"timeZone":{"type":"string"},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"privateCopy":{"type":"boolean"},"recurrence":{"type":"array","items":{"type":"string"}},"recurringEventId":{"type":"string"},"reminders":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"overrides":{"type":"array","items":{"$ref":"#/components/schemas/EventReminder"}},"useDefault":{"type":"boolean"},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"sequence":{"type":"integer","format":"int32"},"source":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"title":{"type":"string"},"url":{"type":"string"},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"start":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"date":{"$ref":"#/components/schemas/DateTime"},"dateTime":{"$ref":"#/components/schemas/DateTime"},"timeZone":{"type":"string"},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"status":{"type":"string"},"summary":{"type":"string"},"transparency":{"type":"string"},"updated":{"$ref":"#/components/schemas/DateTime"},"visibility":{"type":"string"},"icalUID":{"type":"string"},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"EventAttachment":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"fileId":{"type":"string"},"fileUrl":{"type":"string"},"iconLink":{"type":"string"},"mimeType":{"type":"string"},"title":{"type":"string"},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"EventAttendee":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"additionalGuests":{"type":"integer","format":"int32"},"comment":{"type":"string"},"displayName":{"type":"string"},"email":{"type":"string"},"id":{"type":"string"},"optional":{"type":"boolean"},"organizer":{"type":"boolean"},"resource":{"type":"boolean"},"responseStatus":{"type":"string"},"self":{"type":"boolean"},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"EventReminder":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"method":{"type":"string"},"minutes":{"type":"integer","format":"int32"},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"Events":{"type":"object","properties":{"classInfo":{"$ref":"#/components/schemas/ClassInfo"},"accessRole":{"type":"string"},"defaultReminders":{"type":"array","items":{"$ref":"#/components/schemas/EventReminder"}},"description":{"type":"string"},"etag":{"type":"string"},"items":{"type":"array","items":{"$ref":"#/components/schemas/Event"}},"kind":{"type":"string"},"nextPageToken":{"type":"string"},"nextSyncToken":{"type":"string"},"summary":{"type":"string"},"timeZone":{"type":"string"},"updated":{"$ref":"#/components/schemas/DateTime"},"factory":{"$ref":"#/components/schemas/JsonFactory"},"unknownKeys":{"type":"object","additionalProperties":{"type":"object"}},"empty":{"type":"boolean"}},"additionalProperties":{"type":"object"}},"FieldInfo":{"type":"object","properties":{"field":{"type":"object","properties":{"name":{"type":"string"},"modifiers":{"type":"integer","format":"int32"},"synthetic":{"type":"boolean"},"declaredAnnotations":{"type":"array","items":{"type":"object"}},"accessible":{"type":"boolean","deprecated":true},"genericType":{"type":"object","properties":{"typeName":{"type":"string"}}},"enumConstant":{"type":"boolean"},"annotatedType":{"type":"object","properties":{"annotations":{"type":"array","items":{"type":"object"}},"declaredAnnotations":{"type":"array","items":{"type":"object"}},"type":{"type":"object","properties":{"typeName":{"type":"string"}}}}},"annotations":{"type":"array","items":{"type":"object"}}}},"name":{"type":"string"},"primitive":{"type":"boolean"},"genericType":{"type":"object","properties":{"typeName":{"type":"string"}}},"final":{"type":"boolean"},"tersMethodForField":{"type":"array","writeOnly":true,"items":{"type":"object","properties":{"name":{"type":"string"},"modifiers":{"type":"integer","format":"int32"},"typeParameters":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"bounds":{"type":"array","items":{"type":"object","properties":{"typeName":{"type":"string"}}}},"annotatedBounds":{"type":"array","items":{"type":"object","properties":{"annotations":{"type":"array","items":{"type":"object"}},"declaredAnnotations":{"type":"array","items":{"type":"object"}},"type":{"type":"object","properties":{"typeName":{"type":"string"}}}}}},"typeName":{"type":"string"},"annotations":{"type":"array","items":{"type":"object"}},"declaredAnnotations":{"type":"array","items":{"type":"object"}}}}},"synthetic":{"type":"boolean"},"declaredAnnotations":{"type":"array","items":{"type":"object"}},"accessible":{"type":"boolean","deprecated":true},"varArgs":{"type":"boolean"},"parameterCount":{"type":"integer","format":"int32"},"parameterAnnotations":{"type":"array","items":{"type":"array","items":{"type":"object"}}},"genericParameterTypes":{"type":"array","items":{"type":"object","properties":{"typeName":{"type":"string"}}}},"genericExceptionTypes":{"type":"array","items":{"type":"object","properties":{"typeName":{"type":"string"}}}},"default":{"type":"boolean"},"genericReturnType":{"type":"object","properties":{"typeName":{"type":"string"}}},"bridge":{"type":"boolean"},"defaultValue":{"type":"object"},"annotatedReturnType":{"type":"object","properties":{"annotations":{"type":"array","items":{"type":"object"}},"declaredAnnotations":{"type":"array","items":{"type":"object"}},"type":{"type":"object","properties":{"typeName":{"type":"string"}}}}},"annotatedParameterTypes":{"type":"array","items":{"type":"object","properties":{"annotations":{"type":"array","items":{"type":"object"}},"declaredAnnotations":{"type":"array","items":{"type":"object"}},"type":{"type":"object","properties":{"typeName":{"type":"string"}}}}}},"parameters":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"modifiers":{"type":"integer","format":"int32"},"synthetic":{"type":"boolean"},"annotations":{"type":"array","items":{"type":"object"}},"declaredAnnotations":{"type":"array","items":{"type":"object"}},"annotatedType":{"type":"object","properties":{"annotations":{"type":"array","items":{"type":"object"}},"declaredAnnotations":{"type":"array","items":{"type":"object"}},"type":{"type":"object","properties":{"typeName":{"type":"string"}}}}},"parameterizedType":{"type":"object","properties":{"typeName":{"type":"string"}}},"varArgs":{"type":"boolean"},"namePresent":{"type":"boolean"},"declaringExecutable":{"type":"object","properties":{"name":{"type":"string"},"modifiers":{"type":"integer","format":"int32"},"typeParameters":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"},"bounds":{"type":"array","items":{"type":"object","properties":{"typeName":{"type":"string"}}}},"genericDeclaration":{"type":"object"},"annotatedBounds":{"type":"array","items":{"type":"object","properties":{"annotations":{"type":"array","items":{"type":"object"}},"declaredAnnotations":{"type":"array","items":{"type":"object"}},"type":{"type":"object","properties":{"typeName":{"type":"string"}}}}}},"typeName":{"type":"string"},"annotations":{"type":"array","items":{"type":"object"}},"declaredAnnotations":{"type":"array","items":{"type":"object"}}}}},"synthetic":{"type":"boolean"},"declaredAnnotations":{"type":"array","items":{"type":"object"}},"varArgs":{"type":"boolean"},"annotatedParameterTypes":{"type":"array","items":{"type":"object","properties":{"annotations":{"type":"array","items":{"type":"object"}},"declaredAnnotations":{"type":"array","items":{"type":"object"}},"type":{"type":"object","properties":{"typeName":{"type":"string"}}}}}},"parameterCount":{"type":"integer","format":"int32"},"parameterAnnotations":{"type":"array","items":{"type":"array","items":{"type":"object"}}},"genericParameterTypes":{"type":"array","items":{"type":"object","properties":{"typeName":{"type":"string"}}}},"genericExceptionTypes":{"type":"array","items":{"type":"object","properties":{"typeName":{"type":"string"}}}},"annotatedReturnType":{"type":"object","properties":{"annotations":{"type":"array","items":{"type":"object"}},"declaredAnnotations":{"type":"array","items":{"type":"object"}},"type":{"type":"object","properties":{"typeName":{"type":"string"}}}}},"annotatedReceiverType":{"type":"object","properties":{"annotations":{"type":"array","items":{"type":"object"}},"declaredAnnotations":{"type":"array","items":{"type":"object"}},"type":{"type":"object","properties":{"typeName":{"type":"string"}}}}},"annotatedExceptionTypes":{"type":"array","items":{"type":"object","properties":{"annotations":{"type":"array","items":{"type":"object"}},"declaredAnnotations":{"type":"array","items":{"type":"object"}},"type":{"type":"object","properties":{"typeName":{"type":"string"}}}}}},"annotations":{"type":"array","items":{"type":"object"}},"accessible":{"type":"boolean","deprecated":true}}},"implicit":{"type":"boolean"}}}},"annotatedReceiverType":{"type":"object","properties":{"annotations":{"type":"array","items":{"type":"object"}},"declaredAnnotations":{"type":"array","items":{"type":"object"}},"type":{"type":"object","properties":{"typeName":{"type":"string"}}}}},"annotatedExceptionTypes":{"type":"array","items":{"type":"object","properties":{"annotations":{"type":"array","items":{"type":"object"}},"declaredAnnotations":{"type":"array","items":{"type":"object"}},"type":{"type":"object","properties":{"typeName":{"type":"string"}}}}}},"annotations":{"type":"array","items":{"type":"object"}}}}},"classInfo":{"$ref":"#/components/schemas/ClassInfo"}}},"JsonFactory":{"type":"object"},"FacilityPageResponseDTO":{"type":"object"},"PageFacilityDetailsResponseDTO":{"type":"object","properties":{"totalPages":{"type":"integer","format":"int32"},"totalElements":{"type":"integer","format":"int64"},"size":{"type":"integer","format":"int32"},"content":{"type":"array","items":{"$ref":"#/components/schemas/FacilityDetailsResponseDTO"}},"number":{"type":"integer","format":"int32"},"sort":{"type":"array","items":{"$ref":"#/components/schemas/SortObject"}},"first":{"type":"boolean"},"last":{"type":"boolean"},"numberOfElements":{"type":"integer","format":"int32"},"pageable":{"$ref":"#/components/schemas/PageableObject"},"empty":{"type":"boolean"}}}},"securitySchemes":{"Bearer Authentication":{"type":"http","scheme":"bearer","bearerFormat":"JWT"}}}}
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "PublicPlus",
+    "description": "공공체육시설 활성화 사이트 공공플러스입니다!",
+    "contact": {
+      "name": "데브코스 통합 파이널 프로젝트 11팀 00+ 백엔드 깃허브 채널",
+      "url": "https://github.com/prgrms-web-devcourse-final-project/WEB1_2_PublicPlus_BE"
+    },
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8080",
+      "description": "Generated server url"
+    }
+  ],
+  "security": [
+    {
+      "Bearer Authentication": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "FacilityController",
+      "description": "시설 검색정보, 상세정보를 다루는 API입니다."
+    },
+    {
+      "name": "UserController",
+      "description": "사용자 관련 처리를 하는 컨트롤러입니다(회원가입,로그인,로그아웃,토큰 등등)"
+    },
+    {
+      "name": "EmailVerificationController",
+      "description": "이메일 인증메일을 보내거나 이메일에 대한 확인 검증을 합니다"
+    }
+  ],
+  "paths": {
+    "/api/meetingboard/{mbId}": {
+      "get": {
+        "tags": ["meeting-board-controller"],
+        "operationId": "getMeetingBoardById",
+        "parameters": [
+          {
+            "name": "mbId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["meeting-board-controller"],
+        "operationId": "updateMeetingBoard",
+        "parameters": [
+          {
+            "name": "mbId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MeetingBoardRequestDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["meeting-board-controller"],
+        "operationId": "deleteMeetingBoard",
+        "parameters": [
+          {
+            "name": "mbId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/google-calendar/event": {
+      "put": {
+        "tags": ["event-controller"],
+        "operationId": "updateEvent",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ActivityUpdateDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["event-controller"],
+        "operationId": "createEvent",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ActivityCreateDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/facility-details/{id}/reviews/{reviewId}": {
+      "put": {
+        "tags": ["review-controller"],
+        "operationId": "updateReview",
+        "parameters": [
+          {
+            "name": "reviewId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReviewDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReviewDTO"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["review-controller"],
+        "operationId": "deleteReview",
+        "parameters": [
+          {
+            "name": "reviewId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/facility-detail/{facilityId}": {
+      "get": {
+        "tags": ["FacilityController"],
+        "summary": "시설 상세 정보 페이지 조회",
+        "description": "시설 ID로 상세 정보를 조회합니다.",
+        "operationId": "readFacilityDetails",
+        "parameters": [
+          {
+            "name": "facilityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "성공적으로 시설 상세 정보를 조회했습니다.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/FacilityDetailsResponseDTO"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "시설을 찾을 수 없습니다.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/FacilityDetailsResponseDTO"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["FacilityController"],
+        "summary": "시설 상세 정보 업데이트",
+        "description": "시설 상세 정보를 업데이트합니다.",
+        "operationId": "updateFacilityDetail",
+        "parameters": [
+          {
+            "name": "facilityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FacilityDetailsUpdateDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "성공적으로 시설 상세 정보가 업데이트되었습니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FacilityDetailsResponseDTO"
+                },
+                "example": {
+                  "facilityId": "S210401100008601453",
+                  "facilityName": "○ [평일] (주간) 마포 난지천 인조잔디축구장 (업데이트)",
+                  "facilityCategory": "FOOTBALL_FIELD",
+                  "area": "마포구",
+                  "priceType": true,
+                  "facilityImage": "https://example.com/image.jpg",
+                  "reservationStartDate": "2024-11-27T01:44:05.959Z",
+                  "reservationEndDate": "2024-11-27T01:44:05.959Z",
+                  "facilityNumber": "02-3153-9874",
+                  "reservationURL": "https://example.com/reserve",
+                  "facilityLocation": "서울특별시 산악문화체험센터>난지천인조잔디축구장",
+                  "facilityDescription": "1. 공공시설 예약서비스 이용시 필수 준수사항...",
+                  "serviceStartDate": "2024-01-01",
+                  "serviceEndDate": "2024-12-31"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "업데이트 실패",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseDTO"
+                },
+                "example": {
+                  "message": "Invalid input data"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "시설을 찾을 수 없습니다.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseDTO"
+                },
+                "example": {
+                  "message": "Facility not found"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["FacilityController"],
+        "summary": "시설 상세 정보 삭제",
+        "description": "시설 상세 정보를 삭제합니다.",
+        "operationId": "deleteFacilityDetail",
+        "parameters": [
+          {
+            "name": "facilityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "성공적으로 시설 상세 정보가 삭제되었습니다.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "삭제 실패",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "시설을 찾을 수 없습니다.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/activity/{activityId}": {
+      "get": {
+        "tags": ["activity-controller"],
+        "operationId": "getActivity",
+        "parameters": [
+          {
+            "name": "activityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityResponseDTO"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["activity-controller"],
+        "operationId": "updateActivity",
+        "parameters": [
+          {
+            "name": "activityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ActivityUpdateDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityResponseDTO"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["activity-controller"],
+        "operationId": "deleteActivity",
+        "parameters": [
+          {
+            "name": "activityId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/calendar/{summary}": {
+      "post": {
+        "tags": ["calendar-controller"],
+        "operationId": "createCalendar",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/refresh/header": {
+      "post": {
+        "tags": ["UserController"],
+        "summary": "토큰 재발급",
+        "description": "HTTP헤더에 담긴 refresh_token을 이용해 access_token을 재발급합니다",
+        "operationId": "resignAccessTokenByHeader",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "정상 반환",
+            "content": {
+              "application/json": {
+                "example": {
+                  "bearer": "Bearer",
+                  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+                  "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+                  "userId": "sda1fsd3-ds6au-fs3fds5"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "토큰이 만료되거나, refresh_token이 아닌 경우",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "httpStatus": "BAD_REQUEST",
+                  "message": "유효하지 않은 토큰입니다"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/refresh/cookie": {
+      "post": {
+        "tags": ["UserController"],
+        "summary": "토큰 재발급",
+        "description": "(현재미구현)쿠키에 담긴 refresh토큰을 이용해 access토큰을 재발급합니다",
+        "operationId": "resignAccessTokenByCookie",
+        "parameters": [
+          {
+            "name": "refresh_token",
+            "in": "cookie",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "정상 반환",
+            "content": {
+              "application/json": {
+                "example": {
+                  "bearer": "Bearer",
+                  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+                  "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+                  "userId": "sda1fsd3-ds6au-fs3fds5"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "토큰이 만료되거나, refresh_token이 아닌 경우",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "httpStatus": "BAD_REQUEST",
+                  "message": "유효하지 않은 토큰입니다"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/profile/{userId}": {
+      "post": {
+        "tags": ["UserController"],
+        "summary": "프로필 사진 변경",
+        "description": "UserId를 이용해 프로필 사진을 변경합니다",
+        "operationId": "changeProfile",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "multipartFile": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "정상 반환",
+            "content": {
+              "application/json": {
+                "example": {
+                  "message": "프로필 사진 변경 완료"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "이미지 파일이 아니거나, 파일을 첨부하지 않았을 경우",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "httpStatus": "BAD_REQUEST",
+                  "message": "파일이 존재하지 않거나, 파일타입이 맞지 않습니다"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "파일 경로 설정에 문제가 생겼을 경우",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "httpStatus": "BAD_GATEWAY",
+                  "message": "디렉토리 설정이 실패했습니다"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/password/{userId}": {
+      "post": {
+        "tags": ["UserController"],
+        "summary": "비밀번호 변경",
+        "description": "UserId를 이용해 비밀번호를 변경합니다",
+        "operationId": "changePassword",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangePasswordDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "정상 반환",
+            "content": {
+              "application/json": {
+                "example": {
+                  "message": "비밀번호 변경 완료"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "비밀번호 재확인 로직을 통과하지 못했을 경우",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "httpStatus": "BAD_REQUEST",
+                  "message": "암호가 일치하지 않습니다"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/login": {
+      "post": {
+        "tags": ["UserController"],
+        "summary": "로그인",
+        "description": "이메일, 암호를 입력하여 로그인합니다",
+        "operationId": "login",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserLoginDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "정상 반환",
+            "content": {
+              "application/json": {
+                "example": "{\n  \"bearer\": \"Bearer\",\n  \"access_token\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\",\n  \"refresh_token\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"  \"userId\": \"sda1fsd3-ds6au-fs3fds5\"}"
+              }
+            }
+          },
+          "400": {
+            "description": "입력한 이메일이나 암호가 회원 확인 로직을 통과하지 못했을 경우",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "httpStatus": "BAD_REQUEST",
+                  "message": "암호가 일치하지 않습니다"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/join": {
+      "post": {
+        "tags": ["UserController"],
+        "summary": "회원가입",
+        "description": "이메일, 암호, 닉네임을 입력하여 회원가입을 합니다",
+        "operationId": "join",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserJoinDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "비밀번호 확인 로직을 통과하지 못했을 경우",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "httpStatus": "BAD_REQUEST",
+                  "message": "암호가 일치하지 않습니다"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/push/send": {
+      "post": {
+        "tags": ["push-notification-controller"],
+        "operationId": "sendPushNotification",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationCreateDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notification/send": {
+      "post": {
+        "tags": ["notification-controller"],
+        "operationId": "sendPushNotification_1",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/meetingboard": {
+      "get": {
+        "tags": ["meeting-board-controller"],
+        "operationId": "getAllMeetingBoards",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["meeting-board-controller"],
+        "operationId": "createMeetingBoard",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MeetingBoardRequestDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/fcm/save-token": {
+      "post": {
+        "tags": ["fcm-controller"],
+        "operationId": "saveToken",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FCMTokenRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/facility-details/{id}/reviews": {
+      "get": {
+        "tags": ["review-controller"],
+        "operationId": "getReviewsByFacility",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["review-controller"],
+        "operationId": "createReview",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReviewDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReviewDTO"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/facility-detail/filter": {
+      "post": {
+        "tags": ["FacilityController"],
+        "summary": "시설 필터링 검색",
+        "description": "시설 검색정보를 여러 조건으로 필터링하여 조회합니다.",
+        "operationId": "facilityFilter",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FacilityFilterDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "필터링된 시설 목록 조회 성공",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageFacilityResponseDTO"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "필터링 에러",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponseDTO"
+                },
+                "example": {
+                  "message": "Invalid input data"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/facility-detail/all-memory": {
+      "post": {
+        "tags": ["FacilityController"],
+        "summary": "모든 시설 상세 정보 저장",
+        "description": "서울시 공공 서비스예약의 모든 시설 데이터를 API를 통해 가져와서 저장합니다.",
+        "operationId": "addAllFacilityDetails",
+        "responses": {
+          "200": {
+            "description": "성공적으로 모든 시설 상세 정보를 저장했습니다.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "데이터 수집에 실패했습니다.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/email": {
+      "get": {
+        "tags": ["EmailVerificationController"],
+        "summary": "검증",
+        "description": "보낸 코드값이 서버의 저장값과 일치하는지 확인합니다",
+        "operationId": "verifyCode",
+        "parameters": [
+          {
+            "name": "email",
+            "in": "query",
+            "description": "인증번호를 보낸 email 주소",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "인증번호를 보낸 email 주소",
+              "example": "example@example.com"
+            },
+            "example": "example@example.com"
+          },
+          {
+            "name": "code",
+            "in": "query",
+            "description": "받은 인증번호",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "받은 인증번호",
+              "example": 123456
+            },
+            "example": 123456
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "인증 성공",
+            "content": {
+              "application/json": {
+                "example": {
+                  "message": "인증 성공"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "인증 실패",
+            "content": {
+              "application/json": {
+                "example": {
+                  "message": "인증 실패"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["EmailVerificationController"],
+        "summary": "이메일 발송",
+        "description": "이메일 인증을 위한 코드를 발송합니다",
+        "operationId": "sendCode",
+        "parameters": [
+          {
+            "name": "email",
+            "in": "query",
+            "description": "인증번호를 보낼 email 주소",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "인증번호를 보낼 email 주소",
+              "example": "example@example.com"
+            },
+            "example": "example@example.com"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "정상 반환",
+            "content": {
+              "application/json": {
+                "example": {
+                  "message": "발송 완료"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "이미 가입되어있는 이메일인 경우",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "httpStatus": "BAD_REQUEST",
+                  "message": "이미 가입된 이메일입니다"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/activity": {
+      "post": {
+        "tags": ["activity-controller"],
+        "operationId": "createActivity",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ActivityCreateDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityResponseDTO"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/nickname/{userId}": {
+      "patch": {
+        "tags": ["UserController"],
+        "summary": "닉네임 변경",
+        "description": "UserId를 이용해 닉네임을 변경합니다(도메인 규칙 : 2~10자 사이의 한글,영어소문자,숫자만)",
+        "operationId": "updateNickname",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserChangeInfoDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "정상 반환",
+            "content": {
+              "application/json": {
+                "example": {
+                  "message": "닉네임 변경 완료"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "닉네임 변경 규칙을 지키지 않았을 경우",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "httpStatus": "BAD_REQUEST",
+                  "message": "닉네임을 다시 설정해주세요"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/description/{userId}": {
+      "patch": {
+        "tags": ["UserController"],
+        "summary": "소개글 변경",
+        "description": "UserId를 이용해 소개글을 변경합니다",
+        "operationId": "updateDescription",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserChangeInfoDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "정상 반환",
+            "content": {
+              "application/json": {
+                "example": {
+                  "message": "소개글 수정 완료"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/oauth2/naver": {
+      "get": {
+        "tags": ["oauth-2-controller"],
+        "operationId": "naverOauth",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/oauth2/kakao": {
+      "get": {
+        "tags": ["oauth-2-controller"],
+        "operationId": "kakaoOauth",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/oauth2/google": {
+      "get": {
+        "tags": ["oauth-2-controller"],
+        "operationId": "googleOauth",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tags": {
+      "get": {
+        "tags": ["tag-controller"],
+        "operationId": "getTags",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TagDTO"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/calendars": {
+      "get": {
+        "tags": ["calendar-controller"],
+        "operationId": "listCalendars",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/{userId}": {
+      "get": {
+        "tags": ["UserController"],
+        "summary": "회원 정보 조회",
+        "description": "UserId를 이용해 회원정보를 조회합니다",
+        "operationId": "findMyInformation",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "정상 반환",
+            "content": {
+              "application/json": {
+                "example": {
+                  "userId": "adf2ds3-das4fs2daf-ds4a3fn23",
+                  "email": "example@example.com",
+                  "profile_image": "BAD_REQUEST",
+                  "nickname": "만득이",
+                  "description": "안녕하세요. 반갑습니다",
+                  "role": "USER"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["UserController"],
+        "summary": "회원 탈퇴",
+        "description": "UserId를 이용해 회원정보를 삭제합니다",
+        "operationId": "deleteUser",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "정상 반환",
+            "content": {
+              "application/json": {
+                "example": {
+                  "message": "회원 탈퇴 완료"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/logout": {
+      "get": {
+        "tags": ["UserController"],
+        "summary": "로그아웃",
+        "description": "로그아웃을 합니다.",
+        "operationId": "logout",
+        "responses": {
+          "204": {
+            "description": "로그아웃 완료"
+          }
+        }
+      }
+    },
+    "/api/google-calendar/event/events": {
+      "get": {
+        "tags": ["event-controller"],
+        "operationId": "listEvents",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Events"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/facility-detail/list": {
+      "get": {
+        "tags": ["FacilityController"],
+        "summary": "시설 목록 페이지 조회",
+        "description": "모든 시설 목록을 페이지 단위로 조회합니다.",
+        "operationId": "getAllFacilities",
+        "responses": {
+          "200": {
+            "description": "시설 목록 조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FacilityPageResponseDTO"
+                },
+                "example": {
+                  "content": [
+                    {
+                      "facilityId": "S210401100008601453",
+                      "facilityName": "마포 난지천 인조잔디축구장",
+                      "area": "마포구",
+                      "facilityCategory": "FOOTBALL_FIELD",
+                      "reservationStartDate": "2024-11-27T01:44:05.959Z",
+                      "reservationEndDate": "2024-11-27T01:44:05.959Z"
+                    },
+                    {
+                      "facilityId": "S210401100008601454",
+                      "facilityName": "강동구 실내 배드민턴장",
+                      "area": "강동구",
+                      "facilityCategory": "BADMINTON_COURT",
+                      "reservationStartDate": "2024-11-28T01:44:05.959Z",
+                      "reservationEndDate": "2024-11-28T01:44:05.959Z"
+                    }
+                  ],
+                  "pageable": {
+                    "pageNumber": 0,
+                    "pageSize": 10,
+                    "sort": {
+                      "sorted": true,
+                      "unsorted": false,
+                      "empty": false
+                    }
+                  },
+                  "totalElements": 200,
+                  "totalPages": 20,
+                  "last": false,
+                  "first": true,
+                  "size": 10,
+                  "number": 0,
+                  "sort": {
+                    "sorted": true,
+                    "unsorted": false,
+                    "empty": false
+                  },
+                  "numberOfElements": 10
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/facility-detail/details": {
+      "get": {
+        "tags": ["FacilityController"],
+        "summary": "시설 상세 정보 목록 조회",
+        "description": "모든 시설 상세 정보를 페이지 단위로 조회합니다.",
+        "operationId": "getAllFacilityDetails",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageFacilityDetailsResponseDTO"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/google-calendar/event/eventId": {
+      "delete": {
+        "tags": ["event-controller"],
+        "operationId": "deleteEvent",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "LocalTime": {
+        "type": "object",
+        "properties": {
+          "hour": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "minute": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "second": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "nano": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "MeetingBoardRequestDTO": {
+        "required": [
+          "maxParticipants",
+          "mbContent",
+          "mbDate",
+          "mbHost",
+          "mbLocation",
+          "mbTime",
+          "mbTitle",
+          "sportType"
+        ],
+        "type": "object",
+        "properties": {
+          "sportType": {
+            "type": "string",
+            "enum": [
+              "BADMINTON",
+              "BASEBALL",
+              "BASKETBALL",
+              "SOCCER",
+              "SWIMMING",
+              "TENNIS"
+            ]
+          },
+          "mbTitle": {
+            "type": "string"
+          },
+          "mbContent": {
+            "maxLength": 500,
+            "minLength": 0,
+            "type": "string"
+          },
+          "mbDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "mbTime": {
+            "$ref": "#/components/schemas/LocalTime"
+          },
+          "mbLocation": {
+            "type": "string"
+          },
+          "mbHost": {
+            "type": "string"
+          },
+          "maxParticipants": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "ActivityUpdateDTO": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "googleCalenderId": {
+            "type": "string"
+          },
+          "maxAttendees": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "ReviewDTO": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "facilityId": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "rating": {
+            "type": "number",
+            "format": "double"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "likes": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "views": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "FacilityDetailsUpdateDTO": {
+        "type": "object",
+        "properties": {
+          "facilityId": {
+            "type": "string",
+            "description": "시설 고유 ID",
+            "example": "S210401100008601453"
+          },
+          "facilityName": {
+            "type": "string",
+            "description": "시설 이름",
+            "example": "○ [평일] (주간) 마포 난지천 인조잔디축구장 (업데이트)"
+          },
+          "facilityCategory": {
+            "type": "string",
+            "description": "시설 카테고리",
+            "example": "FOOTBALL",
+            "enum": [
+              "FOOTBALL_FIELD",
+              "FUTSAL_FIELD",
+              "FOOT_VOLLEYBALL_FIELD",
+              "BASEBALL_FIELD",
+              "TENNIS_FIELD",
+              "BASKETBALL_FIELD",
+              "VOLLEYBALL_FIELD",
+              "MULTIPURPOSE_FIELD",
+              "SPORTS_FIELD",
+              "GYM",
+              "BADMINTON_FIELD",
+              "TABLE_TENNIS_FIELD",
+              "EDUCATIONAL_FACILITY",
+              "SWIMMING_POOL",
+              "GOLF_FIELD"
+            ]
+          },
+          "area": {
+            "type": "string",
+            "description": "시설 지역",
+            "example": "마포구"
+          },
+          "priceType": {
+            "type": "boolean",
+            "description": "무료(true) / 유료(false)",
+            "example": true
+          },
+          "facilityImage": {
+            "type": "string",
+            "description": "시설 이미지 URL",
+            "example": "http://example.com/facility.jpg"
+          },
+          "reservationStartDate": {
+            "type": "string",
+            "description": "서비스 시작 날짜",
+            "format": "date-time"
+          },
+          "reservationEndDate": {
+            "type": "string",
+            "description": "서비스 종료 날짜",
+            "format": "date-time"
+          },
+          "facilityNumber": {
+            "type": "string",
+            "description": "시설 전화번호",
+            "example": "02-3153-9874"
+          },
+          "reservationURL": {
+            "type": "string",
+            "description": "예약 URL",
+            "example": "http://example.com/reservation"
+          },
+          "facilityLocation": {
+            "type": "string",
+            "description": "시설 상세 주소",
+            "example": "서울특별시 산악문화체험센터>난지천인조잔디축구장"
+          },
+          "facilityDescription": {
+            "type": "string",
+            "description": "시설 설명",
+            "example": "1. 공공시설 예약서비스 이용시 필수 준수사항..."
+          },
+          "serviceStartDate": {
+            "type": "string",
+            "description": "서비스 시작 날짜 (String 형식)",
+            "example": "2024-01-01"
+          },
+          "serviceEndDate": {
+            "type": "string",
+            "description": "서비스 종료 날짜 (String 형식)",
+            "example": "2024-12-31"
+          }
+        }
+      },
+      "ErrorResponseDTO": {
+        "type": "object",
+        "properties": {
+          "errorCode": {
+            "type": "string",
+            "description": "에러 코드"
+          },
+          "message": {
+            "type": "string",
+            "description": "에러 메시지"
+          },
+          "details": {
+            "type": "string",
+            "description": "에러에 대한 세부 설명"
+          }
+        }
+      },
+      "FacilityDetailsResponseDTO": {
+        "type": "object",
+        "properties": {
+          "facilityId": {
+            "type": "string",
+            "description": "시설 고유 ID",
+            "example": "S210401100008601453"
+          },
+          "facilityName": {
+            "type": "string",
+            "description": "시설 이름",
+            "example": "○ [평일] (주간) 마포 난지천 인조잔디축구장"
+          },
+          "facilityCategory": {
+            "type": "string",
+            "description": "시설 카테고리",
+            "example": "FOOTBALL_FIELD",
+            "enum": [
+              "FOOTBALL_FIELD",
+              "FUTSAL_FIELD",
+              "FOOT_VOLLEYBALL_FIELD",
+              "BASEBALL_FIELD",
+              "TENNIS_FIELD",
+              "BASKETBALL_FIELD",
+              "VOLLEYBALL_FIELD",
+              "MULTIPURPOSE_FIELD",
+              "SPORTS_FIELD",
+              "GYM",
+              "BADMINTON_FIELD",
+              "TABLE_TENNIS_FIELD",
+              "EDUCATIONAL_FACILITY",
+              "SWIMMING_POOL",
+              "GOLF_FIELD"
+            ]
+          },
+          "area": {
+            "type": "string",
+            "description": "시설 지역",
+            "example": "마포구"
+          },
+          "priceType": {
+            "type": "boolean",
+            "description": "무료/유료 여부",
+            "example": true
+          },
+          "facilityImage": {
+            "type": "string",
+            "description": "시설 이미지 URL",
+            "example": "https://example.com/image.jpg"
+          },
+          "reservationStartDate": {
+            "type": "string",
+            "description": "예약 시작 날짜",
+            "format": "date-time"
+          },
+          "reservationEndDate": {
+            "type": "string",
+            "description": "예약 종료 날짜",
+            "format": "date-time"
+          },
+          "facilityNumber": {
+            "type": "string",
+            "description": "시설 전화번호",
+            "example": "02-3153-9874"
+          },
+          "reservationURL": {
+            "type": "string",
+            "description": "시설 예약 URL",
+            "example": "https://example.com/reserve"
+          },
+          "facilityLocation": {
+            "type": "string",
+            "description": "시설 상세 주소",
+            "example": "서울특별시 산악문화체험센터>난지천인조잔디축구장"
+          },
+          "facilityDescription": {
+            "type": "string",
+            "description": "시설 설명",
+            "example": "1. 공공시설 예약서비스 이용시 필수 준수사항..."
+          },
+          "serviceStartDate": {
+            "type": "string",
+            "description": "서비스 시작 날짜",
+            "example": "2024-01-01"
+          },
+          "serviceEndDate": {
+            "type": "string",
+            "description": "서비스 종료 날짜",
+            "example": "2024-12-31"
+          }
+        }
+      },
+      "ActivityResponseDTO": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "maxParticipants": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "currentParticipants": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "eventId": {
+            "type": "string"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "httpStatus": {
+            "type": "string",
+            "enum": [
+              "100 CONTINUE",
+              "101 SWITCHING_PROTOCOLS",
+              "102 PROCESSING",
+              "103 EARLY_HINTS",
+              "103 CHECKPOINT",
+              "200 OK",
+              "201 CREATED",
+              "202 ACCEPTED",
+              "203 NON_AUTHORITATIVE_INFORMATION",
+              "204 NO_CONTENT",
+              "205 RESET_CONTENT",
+              "206 PARTIAL_CONTENT",
+              "207 MULTI_STATUS",
+              "208 ALREADY_REPORTED",
+              "226 IM_USED",
+              "300 MULTIPLE_CHOICES",
+              "301 MOVED_PERMANENTLY",
+              "302 FOUND",
+              "302 MOVED_TEMPORARILY",
+              "303 SEE_OTHER",
+              "304 NOT_MODIFIED",
+              "305 USE_PROXY",
+              "307 TEMPORARY_REDIRECT",
+              "308 PERMANENT_REDIRECT",
+              "400 BAD_REQUEST",
+              "401 UNAUTHORIZED",
+              "402 PAYMENT_REQUIRED",
+              "403 FORBIDDEN",
+              "404 NOT_FOUND",
+              "405 METHOD_NOT_ALLOWED",
+              "406 NOT_ACCEPTABLE",
+              "407 PROXY_AUTHENTICATION_REQUIRED",
+              "408 REQUEST_TIMEOUT",
+              "409 CONFLICT",
+              "410 GONE",
+              "411 LENGTH_REQUIRED",
+              "412 PRECONDITION_FAILED",
+              "413 PAYLOAD_TOO_LARGE",
+              "413 REQUEST_ENTITY_TOO_LARGE",
+              "414 URI_TOO_LONG",
+              "414 REQUEST_URI_TOO_LONG",
+              "415 UNSUPPORTED_MEDIA_TYPE",
+              "416 REQUESTED_RANGE_NOT_SATISFIABLE",
+              "417 EXPECTATION_FAILED",
+              "418 I_AM_A_TEAPOT",
+              "419 INSUFFICIENT_SPACE_ON_RESOURCE",
+              "420 METHOD_FAILURE",
+              "421 DESTINATION_LOCKED",
+              "422 UNPROCESSABLE_ENTITY",
+              "423 LOCKED",
+              "424 FAILED_DEPENDENCY",
+              "425 TOO_EARLY",
+              "426 UPGRADE_REQUIRED",
+              "428 PRECONDITION_REQUIRED",
+              "429 TOO_MANY_REQUESTS",
+              "431 REQUEST_HEADER_FIELDS_TOO_LARGE",
+              "451 UNAVAILABLE_FOR_LEGAL_REASONS",
+              "500 INTERNAL_SERVER_ERROR",
+              "501 NOT_IMPLEMENTED",
+              "502 BAD_GATEWAY",
+              "503 SERVICE_UNAVAILABLE",
+              "504 GATEWAY_TIMEOUT",
+              "505 HTTP_VERSION_NOT_SUPPORTED",
+              "506 VARIANT_ALSO_NEGOTIATES",
+              "507 INSUFFICIENT_STORAGE",
+              "508 LOOP_DETECTED",
+              "509 BANDWIDTH_LIMIT_EXCEEDED",
+              "510 NOT_EXTENDED",
+              "511 NETWORK_AUTHENTICATION_REQUIRED"
+            ]
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "ChangePasswordDTO": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "사용자 이메일",
+            "example": "example@example.com"
+          },
+          "changePassword": {
+            "type": "string",
+            "description": "사용자 비밀번호",
+            "example": "password123"
+          },
+          "checkChangePassword": {
+            "type": "string",
+            "description": "비밀번호 확인",
+            "example": "password123"
+          }
+        }
+      },
+      "UserLoginDTO": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "사용자 이메일",
+            "example": "example@example.com"
+          },
+          "password": {
+            "type": "string",
+            "description": "사용자 비밀번호",
+            "example": "password123"
+          }
+        }
+      },
+      "UserJoinDTO": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "사용자 이메일",
+            "example": "example@example.com"
+          },
+          "password": {
+            "type": "string",
+            "description": "사용자 비밀번호",
+            "example": "password123"
+          },
+          "checkPassword": {
+            "type": "string",
+            "description": "비밀번호 확인",
+            "example": "password123"
+          },
+          "nickname": {
+            "type": "string",
+            "description": "사용자 닉네임",
+            "example": "만득이"
+          }
+        },
+        "description": "회원가입 요청 데이터"
+      },
+      "NotificationCreateDTO": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        }
+      },
+      "NotificationDTO": {
+        "type": "object",
+        "properties": {
+          "notificationId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "title": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          }
+        }
+      },
+      "ActivityCreateDTO": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "googleCalenderId": {
+            "type": "string"
+          },
+          "maxAttendees": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "FCMTokenRequest": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          }
+        }
+      },
+      "FacilityFilterDTO": {
+        "type": "object",
+        "properties": {
+          "facilityName": {
+            "type": "string",
+            "description": "시설 이름"
+          },
+          "facilityCategory": {
+            "type": "string",
+            "description": "시설 카테고리",
+            "example": "축구장",
+            "default": "축구장"
+          },
+          "area": {
+            "type": "string",
+            "description": "시설 지역",
+            "example": "마포구",
+            "default": "마포구"
+          },
+          "priceType": {
+            "type": "boolean",
+            "description": "시설 가격 유형(무료/유료)",
+            "example": true,
+            "default": true
+          }
+        }
+      },
+      "FacilityResponseDTO": {
+        "type": "object",
+        "properties": {
+          "facilityId": {
+            "type": "string"
+          },
+          "facilityName": {
+            "type": "string"
+          },
+          "facilityCategory": {
+            "type": "string",
+            "enum": [
+              "FOOTBALL_FIELD",
+              "FUTSAL_FIELD",
+              "FOOT_VOLLEYBALL_FIELD",
+              "BASEBALL_FIELD",
+              "TENNIS_FIELD",
+              "BASKETBALL_FIELD",
+              "VOLLEYBALL_FIELD",
+              "MULTIPURPOSE_FIELD",
+              "SPORTS_FIELD",
+              "GYM",
+              "BADMINTON_FIELD",
+              "TABLE_TENNIS_FIELD",
+              "EDUCATIONAL_FACILITY",
+              "SWIMMING_POOL",
+              "GOLF_FIELD"
+            ]
+          },
+          "area": {
+            "type": "string"
+          },
+          "priceType": {
+            "type": "boolean"
+          },
+          "facilityImage": {
+            "type": "string"
+          },
+          "reservationStartDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "reservationEndDate": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "PageFacilityResponseDTO": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FacilityResponseDTO"
+            }
+          },
+          "number": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortObject"
+            }
+          },
+          "first": {
+            "type": "boolean"
+          },
+          "last": {
+            "type": "boolean"
+          },
+          "numberOfElements": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageable": {
+            "$ref": "#/components/schemas/PageableObject"
+          },
+          "empty": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PageableObject": {
+        "type": "object",
+        "properties": {
+          "offset": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortObject"
+            }
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "paged": {
+            "type": "boolean"
+          },
+          "unpaged": {
+            "type": "boolean"
+          }
+        }
+      },
+      "SortObject": {
+        "type": "object",
+        "properties": {
+          "direction": {
+            "type": "string"
+          },
+          "nullHandling": {
+            "type": "string"
+          },
+          "ascending": {
+            "type": "boolean"
+          },
+          "property": {
+            "type": "string"
+          },
+          "ignoreCase": {
+            "type": "boolean"
+          }
+        }
+      },
+      "UserChangeInfoDTO": {
+        "type": "object",
+        "properties": {
+          "nickname": {
+            "type": "string",
+            "description": "변경할 닉네임",
+            "example": "만득이"
+          },
+          "description": {
+            "type": "string",
+            "description": "변경할 소개글",
+            "example": "안녕하세요. 반갑습니다."
+          }
+        }
+      },
+      "TagDTO": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "ClassInfo": {
+        "type": "object",
+        "properties": {
+          "ignoreCase": {
+            "type": "boolean"
+          },
+          "names": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "enum": {
+            "type": "boolean"
+          },
+          "fieldInfos": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FieldInfo"
+            }
+          }
+        }
+      },
+      "DateTime": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "dateOnly": {
+            "type": "boolean"
+          },
+          "timeZoneShift": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "EntryPoint": {
+        "type": "object",
+        "properties": {
+          "classInfo": {
+            "$ref": "#/components/schemas/ClassInfo"
+          },
+          "accessCode": {
+            "type": "string"
+          },
+          "entryPointFeatures": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "entryPointType": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "meetingCode": {
+            "type": "string"
+          },
+          "passcode": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "pin": {
+            "type": "string"
+          },
+          "regionCode": {
+            "type": "string"
+          },
+          "uri": {
+            "type": "string"
+          },
+          "factory": {
+            "$ref": "#/components/schemas/JsonFactory"
+          },
+          "unknownKeys": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "empty": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": {
+          "type": "object"
+        }
+      },
+      "Event": {
+        "type": "object",
+        "properties": {
+          "classInfo": {
+            "$ref": "#/components/schemas/ClassInfo"
+          },
+          "anyoneCanAddSelf": {
+            "type": "boolean"
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EventAttachment"
+            }
+          },
+          "attendees": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EventAttendee"
+            }
+          },
+          "attendeesOmitted": {
+            "type": "boolean"
+          },
+          "colorId": {
+            "type": "string"
+          },
+          "conferenceData": {
+            "type": "object",
+            "properties": {
+              "classInfo": {
+                "$ref": "#/components/schemas/ClassInfo"
+              },
+              "conferenceId": {
+                "type": "string"
+              },
+              "conferenceSolution": {
+                "type": "object",
+                "properties": {
+                  "classInfo": {
+                    "$ref": "#/components/schemas/ClassInfo"
+                  },
+                  "iconUri": {
+                    "type": "string"
+                  },
+                  "key": {
+                    "type": "object",
+                    "properties": {
+                      "classInfo": {
+                        "$ref": "#/components/schemas/ClassInfo"
+                      },
+                      "type": {
+                        "type": "string"
+                      },
+                      "factory": {
+                        "$ref": "#/components/schemas/JsonFactory"
+                      },
+                      "unknownKeys": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "object"
+                        }
+                      },
+                      "empty": {
+                        "type": "boolean"
+                      }
+                    },
+                    "additionalProperties": {
+                      "type": "object"
+                    }
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "factory": {
+                    "$ref": "#/components/schemas/JsonFactory"
+                  },
+                  "unknownKeys": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object"
+                    }
+                  },
+                  "empty": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "createRequest": {
+                "type": "object",
+                "properties": {
+                  "classInfo": {
+                    "$ref": "#/components/schemas/ClassInfo"
+                  },
+                  "conferenceSolutionKey": {
+                    "type": "object",
+                    "properties": {
+                      "classInfo": {
+                        "$ref": "#/components/schemas/ClassInfo"
+                      },
+                      "type": {
+                        "type": "string"
+                      },
+                      "factory": {
+                        "$ref": "#/components/schemas/JsonFactory"
+                      },
+                      "unknownKeys": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "object"
+                        }
+                      },
+                      "empty": {
+                        "type": "boolean"
+                      }
+                    },
+                    "additionalProperties": {
+                      "type": "object"
+                    }
+                  },
+                  "requestId": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "object",
+                    "properties": {
+                      "classInfo": {
+                        "$ref": "#/components/schemas/ClassInfo"
+                      },
+                      "statusCode": {
+                        "type": "string"
+                      },
+                      "factory": {
+                        "$ref": "#/components/schemas/JsonFactory"
+                      },
+                      "unknownKeys": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "object"
+                        }
+                      },
+                      "empty": {
+                        "type": "boolean"
+                      }
+                    },
+                    "additionalProperties": {
+                      "type": "object"
+                    }
+                  },
+                  "factory": {
+                    "$ref": "#/components/schemas/JsonFactory"
+                  },
+                  "unknownKeys": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object"
+                    }
+                  },
+                  "empty": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "entryPoints": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntryPoint"
+                }
+              },
+              "notes": {
+                "type": "string"
+              },
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "classInfo": {
+                    "$ref": "#/components/schemas/ClassInfo"
+                  },
+                  "addOnParameters": {
+                    "type": "object",
+                    "properties": {
+                      "classInfo": {
+                        "$ref": "#/components/schemas/ClassInfo"
+                      },
+                      "parameters": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "factory": {
+                        "$ref": "#/components/schemas/JsonFactory"
+                      },
+                      "unknownKeys": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "object"
+                        }
+                      },
+                      "empty": {
+                        "type": "boolean"
+                      }
+                    },
+                    "additionalProperties": {
+                      "type": "object"
+                    }
+                  },
+                  "factory": {
+                    "$ref": "#/components/schemas/JsonFactory"
+                  },
+                  "unknownKeys": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object"
+                    }
+                  },
+                  "empty": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "signature": {
+                "type": "string"
+              },
+              "factory": {
+                "$ref": "#/components/schemas/JsonFactory"
+              },
+              "unknownKeys": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "empty": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "created": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "creator": {
+            "type": "object",
+            "properties": {
+              "classInfo": {
+                "$ref": "#/components/schemas/ClassInfo"
+              },
+              "displayName": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "self": {
+                "type": "boolean"
+              },
+              "factory": {
+                "$ref": "#/components/schemas/JsonFactory"
+              },
+              "unknownKeys": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "empty": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "end": {
+            "type": "object",
+            "properties": {
+              "classInfo": {
+                "$ref": "#/components/schemas/ClassInfo"
+              },
+              "date": {
+                "$ref": "#/components/schemas/DateTime"
+              },
+              "dateTime": {
+                "$ref": "#/components/schemas/DateTime"
+              },
+              "timeZone": {
+                "type": "string"
+              },
+              "factory": {
+                "$ref": "#/components/schemas/JsonFactory"
+              },
+              "unknownKeys": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "empty": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "endTimeUnspecified": {
+            "type": "boolean"
+          },
+          "etag": {
+            "type": "string"
+          },
+          "extendedProperties": {
+            "type": "object",
+            "properties": {
+              "classInfo": {
+                "$ref": "#/components/schemas/ClassInfo"
+              },
+              "shared": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "private": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "factory": {
+                "$ref": "#/components/schemas/JsonFactory"
+              },
+              "unknownKeys": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "empty": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "gadget": {
+            "type": "object",
+            "properties": {
+              "classInfo": {
+                "$ref": "#/components/schemas/ClassInfo"
+              },
+              "display": {
+                "type": "string"
+              },
+              "height": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "iconLink": {
+                "type": "string"
+              },
+              "link": {
+                "type": "string"
+              },
+              "preferences": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "title": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "width": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "factory": {
+                "$ref": "#/components/schemas/JsonFactory"
+              },
+              "unknownKeys": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "empty": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "guestsCanInviteOthers": {
+            "type": "boolean"
+          },
+          "guestsCanModify": {
+            "type": "boolean"
+          },
+          "guestsCanSeeOtherGuests": {
+            "type": "boolean"
+          },
+          "hangoutLink": {
+            "type": "string"
+          },
+          "htmlLink": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "locked": {
+            "type": "boolean"
+          },
+          "organizer": {
+            "type": "object",
+            "properties": {
+              "classInfo": {
+                "$ref": "#/components/schemas/ClassInfo"
+              },
+              "displayName": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "self": {
+                "type": "boolean"
+              },
+              "factory": {
+                "$ref": "#/components/schemas/JsonFactory"
+              },
+              "unknownKeys": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "empty": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "originalStartTime": {
+            "type": "object",
+            "properties": {
+              "classInfo": {
+                "$ref": "#/components/schemas/ClassInfo"
+              },
+              "date": {
+                "$ref": "#/components/schemas/DateTime"
+              },
+              "dateTime": {
+                "$ref": "#/components/schemas/DateTime"
+              },
+              "timeZone": {
+                "type": "string"
+              },
+              "factory": {
+                "$ref": "#/components/schemas/JsonFactory"
+              },
+              "unknownKeys": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "empty": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "privateCopy": {
+            "type": "boolean"
+          },
+          "recurrence": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "recurringEventId": {
+            "type": "string"
+          },
+          "reminders": {
+            "type": "object",
+            "properties": {
+              "classInfo": {
+                "$ref": "#/components/schemas/ClassInfo"
+              },
+              "overrides": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EventReminder"
+                }
+              },
+              "useDefault": {
+                "type": "boolean"
+              },
+              "factory": {
+                "$ref": "#/components/schemas/JsonFactory"
+              },
+              "unknownKeys": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "empty": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "sequence": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "source": {
+            "type": "object",
+            "properties": {
+              "classInfo": {
+                "$ref": "#/components/schemas/ClassInfo"
+              },
+              "title": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              },
+              "factory": {
+                "$ref": "#/components/schemas/JsonFactory"
+              },
+              "unknownKeys": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "empty": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "start": {
+            "type": "object",
+            "properties": {
+              "classInfo": {
+                "$ref": "#/components/schemas/ClassInfo"
+              },
+              "date": {
+                "$ref": "#/components/schemas/DateTime"
+              },
+              "dateTime": {
+                "$ref": "#/components/schemas/DateTime"
+              },
+              "timeZone": {
+                "type": "string"
+              },
+              "factory": {
+                "$ref": "#/components/schemas/JsonFactory"
+              },
+              "unknownKeys": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "empty": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "status": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "transparency": {
+            "type": "string"
+          },
+          "updated": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "visibility": {
+            "type": "string"
+          },
+          "icalUID": {
+            "type": "string"
+          },
+          "factory": {
+            "$ref": "#/components/schemas/JsonFactory"
+          },
+          "unknownKeys": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "empty": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": {
+          "type": "object"
+        }
+      },
+      "EventAttachment": {
+        "type": "object",
+        "properties": {
+          "classInfo": {
+            "$ref": "#/components/schemas/ClassInfo"
+          },
+          "fileId": {
+            "type": "string"
+          },
+          "fileUrl": {
+            "type": "string"
+          },
+          "iconLink": {
+            "type": "string"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "factory": {
+            "$ref": "#/components/schemas/JsonFactory"
+          },
+          "unknownKeys": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "empty": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": {
+          "type": "object"
+        }
+      },
+      "EventAttendee": {
+        "type": "object",
+        "properties": {
+          "classInfo": {
+            "$ref": "#/components/schemas/ClassInfo"
+          },
+          "additionalGuests": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "optional": {
+            "type": "boolean"
+          },
+          "organizer": {
+            "type": "boolean"
+          },
+          "resource": {
+            "type": "boolean"
+          },
+          "responseStatus": {
+            "type": "string"
+          },
+          "self": {
+            "type": "boolean"
+          },
+          "factory": {
+            "$ref": "#/components/schemas/JsonFactory"
+          },
+          "unknownKeys": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "empty": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": {
+          "type": "object"
+        }
+      },
+      "EventReminder": {
+        "type": "object",
+        "properties": {
+          "classInfo": {
+            "$ref": "#/components/schemas/ClassInfo"
+          },
+          "method": {
+            "type": "string"
+          },
+          "minutes": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "factory": {
+            "$ref": "#/components/schemas/JsonFactory"
+          },
+          "unknownKeys": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "empty": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": {
+          "type": "object"
+        }
+      },
+      "Events": {
+        "type": "object",
+        "properties": {
+          "classInfo": {
+            "$ref": "#/components/schemas/ClassInfo"
+          },
+          "accessRole": {
+            "type": "string"
+          },
+          "defaultReminders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EventReminder"
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "etag": {
+            "type": "string"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Event"
+            }
+          },
+          "kind": {
+            "type": "string"
+          },
+          "nextPageToken": {
+            "type": "string"
+          },
+          "nextSyncToken": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "timeZone": {
+            "type": "string"
+          },
+          "updated": {
+            "$ref": "#/components/schemas/DateTime"
+          },
+          "factory": {
+            "$ref": "#/components/schemas/JsonFactory"
+          },
+          "unknownKeys": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "empty": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": {
+          "type": "object"
+        }
+      },
+      "FieldInfo": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "modifiers": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "synthetic": {
+                "type": "boolean"
+              },
+              "declaredAnnotations": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "accessible": {
+                "type": "boolean",
+                "deprecated": true
+              },
+              "genericType": {
+                "type": "object",
+                "properties": {
+                  "typeName": {
+                    "type": "string"
+                  }
+                }
+              },
+              "enumConstant": {
+                "type": "boolean"
+              },
+              "annotatedType": {
+                "type": "object",
+                "properties": {
+                  "annotations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
+                  },
+                  "declaredAnnotations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
+                  },
+                  "type": {
+                    "type": "object",
+                    "properties": {
+                      "typeName": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "annotations": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "tersMethodForField": {
+            "type": "array",
+            "writeOnly": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "modifiers": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "typeParameters": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "annotatedBounds": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "annotations": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            },
+                            "declaredAnnotations": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            },
+                            "type": {
+                              "type": "object",
+                              "properties": {
+                                "typeName": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "bounds": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "typeName": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "typeName": {
+                        "type": "string"
+                      },
+                      "annotations": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        }
+                      },
+                      "declaredAnnotations": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        }
+                      }
+                    }
+                  }
+                },
+                "synthetic": {
+                  "type": "boolean"
+                },
+                "declaredAnnotations": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                },
+                "accessible": {
+                  "type": "boolean",
+                  "deprecated": true
+                },
+                "varArgs": {
+                  "type": "boolean"
+                },
+                "parameterCount": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "parameterAnnotations": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    }
+                  }
+                },
+                "genericParameterTypes": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "typeName": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "genericExceptionTypes": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "typeName": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "default": {
+                  "type": "boolean"
+                },
+                "genericReturnType": {
+                  "type": "object",
+                  "properties": {
+                    "typeName": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "bridge": {
+                  "type": "boolean"
+                },
+                "defaultValue": {
+                  "type": "object"
+                },
+                "annotatedReturnType": {
+                  "type": "object",
+                  "properties": {
+                    "annotations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "declaredAnnotations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "type": {
+                      "type": "object",
+                      "properties": {
+                        "typeName": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "annotatedParameterTypes": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "annotations": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        }
+                      },
+                      "declaredAnnotations": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        }
+                      },
+                      "type": {
+                        "type": "object",
+                        "properties": {
+                          "typeName": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "parameters": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "modifiers": {
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "synthetic": {
+                        "type": "boolean"
+                      },
+                      "annotations": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        }
+                      },
+                      "declaredAnnotations": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        }
+                      },
+                      "annotatedType": {
+                        "type": "object",
+                        "properties": {
+                          "annotations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object"
+                            }
+                          },
+                          "declaredAnnotations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object"
+                            }
+                          },
+                          "type": {
+                            "type": "object",
+                            "properties": {
+                              "typeName": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "parameterizedType": {
+                        "type": "object",
+                        "properties": {
+                          "typeName": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "varArgs": {
+                        "type": "boolean"
+                      },
+                      "namePresent": {
+                        "type": "boolean"
+                      },
+                      "declaringExecutable": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "modifiers": {
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "typeParameters": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "genericDeclaration": {
+                                  "type": "object"
+                                },
+                                "annotatedBounds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "annotations": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "declaredAnnotations": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": {
+                                        "type": "object",
+                                        "properties": {
+                                          "typeName": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "bounds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "typeName": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "typeName": {
+                                  "type": "string"
+                                },
+                                "annotations": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object"
+                                  }
+                                },
+                                "declaredAnnotations": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "synthetic": {
+                            "type": "boolean"
+                          },
+                          "declaredAnnotations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object"
+                            }
+                          },
+                          "varArgs": {
+                            "type": "boolean"
+                          },
+                          "annotatedParameterTypes": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "annotations": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object"
+                                  }
+                                },
+                                "declaredAnnotations": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": {
+                                  "type": "object",
+                                  "properties": {
+                                    "typeName": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "parameterCount": {
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "parameterAnnotations": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            }
+                          },
+                          "genericParameterTypes": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "typeName": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "genericExceptionTypes": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "typeName": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "annotatedReturnType": {
+                            "type": "object",
+                            "properties": {
+                              "annotations": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              },
+                              "declaredAnnotations": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              },
+                              "type": {
+                                "type": "object",
+                                "properties": {
+                                  "typeName": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "annotatedReceiverType": {
+                            "type": "object",
+                            "properties": {
+                              "annotations": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              },
+                              "declaredAnnotations": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              },
+                              "type": {
+                                "type": "object",
+                                "properties": {
+                                  "typeName": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "annotatedExceptionTypes": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "annotations": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object"
+                                  }
+                                },
+                                "declaredAnnotations": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object"
+                                  }
+                                },
+                                "type": {
+                                  "type": "object",
+                                  "properties": {
+                                    "typeName": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "annotations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object"
+                            }
+                          },
+                          "accessible": {
+                            "type": "boolean",
+                            "deprecated": true
+                          }
+                        }
+                      },
+                      "implicit": {
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                },
+                "annotatedReceiverType": {
+                  "type": "object",
+                  "properties": {
+                    "annotations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "declaredAnnotations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "type": {
+                      "type": "object",
+                      "properties": {
+                        "typeName": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "annotatedExceptionTypes": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "annotations": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        }
+                      },
+                      "declaredAnnotations": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        }
+                      },
+                      "type": {
+                        "type": "object",
+                        "properties": {
+                          "typeName": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "annotations": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          },
+          "primitive": {
+            "type": "boolean"
+          },
+          "genericType": {
+            "type": "object",
+            "properties": {
+              "typeName": {
+                "type": "string"
+              }
+            }
+          },
+          "final": {
+            "type": "boolean"
+          },
+          "classInfo": {
+            "$ref": "#/components/schemas/ClassInfo"
+          }
+        }
+      },
+      "JsonFactory": {
+        "type": "object"
+      },
+      "FacilityPageResponseDTO": {
+        "type": "object"
+      },
+      "PageFacilityDetailsResponseDTO": {
+        "type": "object",
+        "properties": {
+          "totalElements": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FacilityDetailsResponseDTO"
+            }
+          },
+          "number": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortObject"
+            }
+          },
+          "first": {
+            "type": "boolean"
+          },
+          "last": {
+            "type": "boolean"
+          },
+          "numberOfElements": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageable": {
+            "$ref": "#/components/schemas/PageableObject"
+          },
+          "empty": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "Bearer Authentication": {
+        "type": "http",
+        "scheme": "Bearer",
+        "bearerFormat": "JWT"
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Ref: QTVY-110
- Tags에 한글로 되어있는 Controller이름을 그대로 사용할 경우, api 생성 시 인식이 안 되어서 User관련 Api가 따로 분류되어 있지 않고 defaultAPI에 있았습니다.
-  api 분류를 위해 영어로 이름 바꾸어놓았습니당!

ex)사용자 컨트롤러 => UserController
이메일 인증 컨트롤러 => EmailVerificationController