### PR TITLE
Fix: API Update 워크플로우 적용 브랜치 제한

### DIFF
--- a/.github/workflows/api-client-generation.yml
+++ b/.github/workflows/api-client-generation.yml
@@ -1,8 +1,10 @@
 name: API Client Generation
 on:
   push:
+    branches:
+      - QTVY-111-swaggerhub  # 특정 브랜치 지정
     paths:
-      - 'src/api/generated/swagger.json'
+      - 'src/api/generated/swagger.json'  # 특정 경로의 파일 변경 시에만 트리거
 
 jobs:
   generate-api:


### PR DESCRIPTION
- github-actions 워크플로우가 전체 브랜치 커밋에 적용되도록 되어 있었어서, swaggerHub브랜치에만 적용되도록 수정했습니다.