### PR TITLE
✏️ Fix: 배포 워크플로우 수정

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,4 +1,4 @@
-name: Deploy Static Website to S3 and Invalidate CloudFront
+name: Deploy Next.js SSR to AWS Lambda@Edge and S3
 
 on:
   push:
@@ -37,11 +37,23 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: 'us-east-1' # Lambda@Edge는 반드시 us-east-1에 배포해야 함
 
-      - name: Deploy to S3
+      - name: Prepare Lambda function
         run: |
-          aws s3 sync out/ s3://${{ secrets.S3_BUCKET_NAME }} --delete
+          cd .next/standalone
+          zip -r ../function.zip ./*
+          cd ../..
+
+      - name: Deploy to Lambda@Edge
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ secrets.LAMBDA_FUNCTION_NAME }} \
+            --zip-file fileb://.next/function.zip
+
+      - name: Deploy static files to S3
+        run: |
+          aws s3 sync .next/static s3://${{ secrets.S3_BUCKET_NAME }}/_next/static --delete
 
       - name: Invalidate CloudFront cache
         run: |

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  output: 'standalone',
   reactStrictMode: true,
   env: {
     NEXT_PUBLIC_KAKAO_MAP_API_KEY: process.env.NEXT_PUBLIC_KAKAO_MAP_API_KEY


### PR DESCRIPTION
- standalone 옵션을 설정
- SSR 및 동적 라우팅([id])이 가능한 상태로 빌드 테스트 완료
   - .next/standalone - Node.js 서버 실행 환경
   - .next/static - 정적 파일들 (CSS, JS, 이미지 등)
- 배포 워크플로우 수정
   - out/ 대신 .next/static을 S3에 배포
   - Lambda 함수 배포 단계 추가
   - AWS 리전을 us-east-1로 고정
   - 빌드 결과물을 Lambda 함수용으로 압축하는 단계 추가
- SSR이 필요한 페이지는 Lambda@Edge에서 처리, 정적 파일은 S3에서 제공